### PR TITLE
[SLDEV-9710] - refactored SLListener to report skipped tests

### DIFF
--- a/robot-custom-integration/README.md
+++ b/robot-custom-integration/README.md
@@ -10,9 +10,10 @@ The SeaLights integration is implemented in the file `SLListener.py`. It provide
 Listener interface to facilitate calls to SeaLights API at appropriate phases of the test suite's lifecycle:
 - `start_suite` -- here we do two things:
   - initialize the test session so that all the tests can be identified by SeaLights as being part of the same session 
-  - request the list of tests to be executed from SeaLights and narrow the test suite to only them 
-- `end_test` -- at this point we report the executed test's result, start and end time to SeaLights 
-- `end_suite` -- closing the test session
+  - request the list of tests to be executed from SeaLights and narrow the test suite to only them
+- `end_suite` -- here we do two things: 
+  - we collect and report test results including start and end time to SeaLights
+  - close the test session
 
 ## Using the SeaLights Listener 
 

--- a/robot-custom-integration/setup.cfg
+++ b/robot-custom-integration/setup.cfg
@@ -1,0 +1,5 @@
+[bdist_wheel]
+# This flag says that the code is written to work on both Python 2 and Python
+# 3. If at all possible, it is good practice to do this. If you cannot, you
+# will need to generate wheels for each Python version that you support.
+universal=1

--- a/robot-custom-integration/setup.py
+++ b/robot-custom-integration/setup.py
@@ -1,0 +1,13 @@
+from setuptools import setup, find_packages
+
+setup(
+    name='sl-python-robot',
+    version='1.0.0',
+    install_requires=["requests==2.26.0"],
+    packages=find_packages(),
+    url='https://github.com/Sealights/sealights-integration-examples/tree/main/robot-custom-integration',
+    license='',
+    author='Bartosz Kaczkowski',
+    author_email='bartosz.kaczkowski@sealights.io',
+    description='Sealights Testing Optimization for Robot Framework'
+)

--- a/robot-custom-integration/sl_python_robot/SLListener.py
+++ b/robot-custom-integration/sl_python_robot/SLListener.py
@@ -3,6 +3,7 @@ import requests
 
 SEALIGHTS_LOG_TAG = '[SeaLights]'
 DUMMY_TEST_NAME = "SeaLights Dummy"
+TEST_STATUS_MAP = {"FAIL": "failed", "SKIP": "skipped"}
 
 
 class SLListener:
@@ -20,12 +21,37 @@ class SLListener:
         self.token = sltoken
         self.bsid = bsid
         self.stage_name = stagename
+        self.excluded_tests = []
         if labid:
             self.labid = labid
         else:
             self.labid = bsid
 
     def start_suite(self, suite, result):
+        self.create_test_session()
+        self.excluded_tests = set(self.get_excluded_tests())
+        print(f'>>>> Skipped tests: {list(self.excluded_tests)}')
+
+        all_tests = set()
+        for test in suite.tests:
+            all_tests.add(test.name)
+            if test.name in self.excluded_tests:
+                test.body.create_keyword(name="SKIP")
+
+        tests_for_execution = list(all_tests - self.excluded_tests)
+        print(f'>>>> Tests for execution: {tests_for_execution}')
+
+    def end_suite(self, date, result):
+        if not self.test_session_id:
+            return
+        test_results = self.build_test_results(result)
+        if test_results:
+            requests.post(self.get_session_url(), json=test_results, headers=self.get_header())
+            print(f'>>>> {SEALIGHTS_LOG_TAG} Results: {test_results}')
+        print(f'>>>> {SEALIGHTS_LOG_TAG} Deleting test session {self.test_session_id}')
+        requests.delete(self.get_session_url(), headers=self.get_header())
+
+    def create_test_session(self):
         initialize_session_request = {'labId': self.labid, 'testStage': self.stage_name, 'bsid': self.bsid}
         response = requests.post(f'{self.base_url}/test-sessions', json=initialize_session_request, headers=self.get_header())
 
@@ -38,59 +64,27 @@ class SLListener:
             self.test_session_id = res["data"]["testSessionId"]
             print(f'>>>> {SEALIGHTS_LOG_TAG} Test session opened, testSessionId: {self.test_session_id}')
 
-        excluded_tests = self.get_excluded_tests()
-        print(f'>>>> Excluded tests: {excluded_tests}')
-
-        all_tests = []
-        for test in suite.tests:
-            all_tests.append(test.name)
-
-        tests_for_execution = list(set(all_tests) - set(excluded_tests))
-        print(f'>>>> Tests for execution: {tests_for_execution}')
-
-        if not tests_for_execution:
-            tests_for_execution = ["a test name that doesn't show up anywhere"]
-        suite.filter(included_tests=tests_for_execution)
-
-        if not suite.has_tests:
-            suite.tests.create(DUMMY_TEST_NAME)
-            suite.tests[0].keywords.create(name='NoOperation')
-        suite.remove_empty_suites()
-
-    def end_test(self, data, result):
-        if not self.test_session_id:
-            return
-
-        if result.status == 'FAIL':
-            test_status = "failed"
-        elif result.status == 'SKIP':
-            test_status = "skipped"
-        else:
-            test_status = "passed"
-
-        start_ms = self.get_epoch_timestamp(result.starttime)
-        end_ms = self.get_epoch_timestamp(result.endtime)
-
-        results = [{"name": result.name, "status": test_status, "start": start_ms, "end": end_ms}]
-        requests.post(f'{self.base_url}/test-sessions/{self.test_session_id}', json=results, headers=self.get_header())
-
-    def end_suite(self, date, result):
-        if not self.test_session_id:
-            return
-        print(f'>>>> {SEALIGHTS_LOG_TAG} Deleting test session {self.test_session_id}')
-        requests.delete(f'{self.base_url}/test-sessions/{self.test_session_id}', headers=self.get_header())
-
     def get_excluded_tests(self):
-        recommendations = requests.get(f'{self.base_url}/test-sessions/{self.test_session_id}/exclude-tests', headers=self.get_header())
-
+        recommendations = requests.get(f'{self.get_session_url()}/exclude-tests', headers=self.get_header())
         print(f'Recommendations: {recommendations.status_code}')
         if recommendations.status_code == 200:
             return recommendations.json()["data"]
-
         return []
 
     def get_header(self):
         return {'Authorization': 'Bearer ' + self.token, 'Content-Type': 'application/json'}
+
+    def get_session_url(self):
+        return f'{self.base_url}/test-sessions/{self.test_session_id}'
+
+    def build_test_results(self, result):
+        tests = []
+        for test in result.tests:
+            test_status = TEST_STATUS_MAP.get(test.status, "passed")
+            start_ms = self.get_epoch_timestamp(result.starttime)
+            end_ms = self.get_epoch_timestamp(result.endtime)
+            tests.append({"name": test.name, "status": test_status, "start": start_ms, "end": end_ms})
+        return tests
 
     def get_epoch_timestamp(self, value):
         dt_value = datetime.datetime.strptime(value, "%Y%m%d %H:%M:%S.%f")


### PR DESCRIPTION
* start_suite now adds the SKIP keyword instead of excluding them so they will be collected and reported with skipped status
* end_test was removed
* end_suite now reports all test results at once
* built example as a python package including setup.py and setup.cfg