### PR TITLE
Align robot custom integration with Python agent listener

### DIFF
--- a/robot-custom-integration/README.md
+++ b/robot-custom-integration/README.md
@@ -1,14 +1,13 @@
 ### SLListener (Robot Framework wrapper) — Usage Guide
 
-The `SLListener.py` provides a Robot Framework listener that integrates your Robot test runs with SeaLights. It creates a test session, optionally narrows execution to recommended tests, instruments Selenium for web footprints, and reports results back to SeaLights.
+The `SLListener.py` file provides a Robot Framework listener that integrates your Robot test runs with SeaLights. It creates a test session, optionally narrows execution to recommended tests, instruments Selenium for web footprints, and reports results back to SeaLights.
 
 ### What it does
 - **Test session lifecycle**: Opens a SeaLights Test Session on suite start and closes it on suite end.
 - **Test selection**: Fetches recommendations and marks excluded tests as `SKIP` before execution.
-- **Tag-based grouping** (optional): When `use_tags=True`, uses the first tag as the test identifier, allowing multiple Robot tests to be grouped under a single SeaLights test.
 - **Tracing**: Starts an OpenTelemetry span per test and sets baggage with test/session identifiers.
 - **Selenium instrumentation**: Monkey-patches `WebDriver.get/close/quit` to communicate with the SeaLights Browser Agent when present.
-- **Results reporting**: Uploads aggregated test results (name, status, start/end) to SeaLights.
+- **Results reporting**: Uploads test results (name, status, start, end) to SeaLights.
 
 ### Requirements
 - Robot Framework (Listener API v3 compatible).
@@ -18,89 +17,68 @@ The `SLListener.py` provides a Robot Framework listener that integrates your Rob
   - **Build Session ID** (`bsid`), or
   - **Lab ID** (`labid`) that has an active build session for the specified stage.
 - **Stage name** (`stagename`) such as `CI`, `Nightly`, etc.
-- **Machine DNS** Robot require `machine_dns` environment variable to be set - this is the url to the application under test
+- **Machine DNS**: Robot requires the `machine_dns` environment variable to be set to the application-under-test URL.
 
-### Listener arguments (positional) (space are supported in params)
-1) `sltoken` (required)
-2) `bsid` (optional if `labid` is provided)
-3) `stagename` (required)
-4) `labid` (optional if `bsid` is provided)
-5) `use_tags` (optional, default: `False`) - Enable tag-based test identification
+### Listener arguments (positional)
+1. `sltoken` (required)
+2. `bsid` (optional if `labid` is provided)
+3. `stagename` (required)
+4. `labid` (optional if `bsid` is provided)
+5. `testprojectid` (optional) - enables support for non-integration build labs
 
 Notes:
 - Provide at least one of `bsid` or `labid`.
 - If both `bsid` and `labid` are provided, the listener resolves the active build session via `labid`.
 - When skipping an optional argument to provide later ones, pass an empty string to preserve positions.
+- When `testprojectid` is provided, it is sent as the `x-sl-testprojectid` HTTP header on all API calls, included in the session creation body, and added as a query parameter when resolving `bsid` from `labid`.
+- This example now mirrors the current Python agent listener contract; the old fifth positional `use_tags` argument is no longer supported here.
 
 ### Quick start
 Use an absolute path to avoid module import collisions. Replace `/path/to/repo` with your local clone path.
 
-With `Build Session Id` example:
+With `Build Session ID`:
 
 ```bash
 export machine_dns="<application-under-test-url>"
 export SL_TOKEN="<your-sealights-token>"
 export BSID="<your-build-session-id>"
-robot --listener "/path/to/repo/robot/SLListener.py:${SL_TOKEN}:${BSID}:CI Tests" /path/to/robot/tests.robot
+robot --listener "/path/to/repo/sl_python_robot/SLListener.py:${SL_TOKEN}:${BSID}:CI Tests" /path/to/robot/tests.robot
 ```
 
-With `labid` example:
+With `labid`:
 
 ```bash
 export machine_dns="<application-under-test-url>"
 export SL_TOKEN="<your-sealights-token>"
 export LAB_ID="<your-lab-id>"
-robot --listener "/path/to/repo/robot/SLListener.py:${SL_TOKEN}::CI Tests:${LAB_ID}" /path/to/robot/tests.robot
+robot --listener "/path/to/repo/sl_python_robot/SLListener.py:${SL_TOKEN}::CI Tests:${LAB_ID}" /path/to/robot/tests.robot
 ```
 
-With `use_tags` enabled:
+With `labid` and `testprojectid` (non-integration build lab):
 
 ```bash
 export machine_dns="<application-under-test-url>"
 export SL_TOKEN="<your-sealights-token>"
-export BSID="<your-build-session-id>"
-robot --listener "/path/to/repo/robot/SLListener.py:${SL_TOKEN}:${BSID}:CI Tests::True" /path/to/robot/tests.robot
+export LAB_ID="<your-lab-id>"
+export TEST_PROJECT_ID="<your-test-project-id>"
+robot --listener "/path/to/repo/sl_python_robot/SLListener.py:${SL_TOKEN}::CI Tests:${LAB_ID}:${TEST_PROJECT_ID}" /path/to/robot/tests.robot
 ```
 
-### Tag-based Test Grouping (`use_tags=True`)
-
-When `use_tags` is enabled, the listener uses the **first tag** of each test as its identifier instead of the test name. This enables:
-
-1. **Grouping multiple Robot tests under one SeaLights test**: Tests with the same first tag are reported as a single test to SeaLights.
-
-2. **Aggregated status reporting**:
-   - All tests with the same tag skipped → `skipped`
-   - Any test with the same tag failed → `failed`
-   - Otherwise → `passed`
-
-3. **Aggregated timing**: Uses the earliest start time and latest end time across all tests with the same tag.
-
-4. **Exclusion by tag**: When SeaLights recommends excluding a test name, all Robot tests with that tag are skipped.
-
-**Example**: If you have three Robot tests:
-- `Login_Chrome` with tag `Login`
-- `Login_Firefox` with tag `Login`
-- `Checkout` with tag `Checkout`
-
-SeaLights will see two tests: `Login` and `Checkout`. If `Login_Chrome` passes but `Login_Firefox` fails, `Login` is reported as `failed`.
-
-**Fallback**: Tests without tags use their test name as the identifier.
-
 ### How endpoints are determined
-- The listener decodes the JWT (without signature verification) and reads `x-sl-server`, e.g. `https://your.sl.server/api`.
-- For Test Session APIs it uses the `sl-api` base by converting `/api` → `/sl-api`.
-- When resolving `bsid` from `labid`, it calls `GET /v1/lab-ids/{labId}/build-sessions/active` on the API base with query params `agentId` and `testStage`.
+- The listener decodes the JWT (without signature verification) and reads `x-sl-server`, for example `https://your.sl.server/api`.
+- For Test Session APIs it uses the `sl-api` base by converting `/api` to `/sl-api`.
+- When resolving `bsid` from `labid`, it calls `GET /v1/lab-ids/{labId}/build-sessions/active` on the API base with query params `agentId`, `testStage`, and `testProjectId` when provided.
 
 ### Test selection behavior
 - On suite start, the listener calls `GET /v1/test-sessions/{id}/exclude-tests`.
-- Test names (or tags when `use_tags=True`) returned from this endpoint are marked as `SKIP` before execution.
+- Test names returned from this endpoint are marked as `SKIP` before execution.
 - If a skipped test has a teardown, it is removed to avoid side effects.
 - Console logs include counts and decisions for transparency.
 
 ### Selenium instrumentation
 - If `selenium` is installed, the listener applies:
   - After `WebDriver.get`: injects a `CustomEvent("set:baggage")` with `x-sl-test-name` and `x-sl-test-session-id`.
-  - On `close`/`quit`: attempts `await window.$SealightsAgent.sendAllFootprints()`.
+  - On `close` and `quit`: attempts `await window.$SealightsAgent.sendAllFootprints()`.
 - Ensure your application pages include the SeaLights Browser Agent so `window.$SealightsAgent` is available to collect web footprints.
 
 ### Logging and environment
@@ -110,34 +88,32 @@ SeaLights will see two tests: `Login` and `Checkout`. If `Login_Chrome` passes b
   - `OTEL_TRACES_EXPORTER=none`
 
 ### Failure and disable behavior
-- Missing `stagename` or missing both `bsid` and `labid` → listener disables itself and logs the reason.
+- Missing `stagename` or missing both `bsid` and `labid` disables the listener and logs the reason.
 - `labid` resolution outcomes:
-  - `200` → sets `bsid` and continues.
-  - `404`, `500`, or other errors → listener is disabled with an explanatory message.
-- Session create or results upload failures are logged with HTTP status codes.
+  - `200` -> sets `bsid` and continues
+  - `404`, `500`, or other errors -> listener is disabled with an explanatory message
+- Session creation or results upload failures are logged with HTTP status codes.
 
 ### Troubleshooting
-- "Listener disabled: Stage name is required" → Provide `stagename` (3rd argument).
-- "Either 'bsid' or 'labId' must be provided" → Pass at least one; for `labid` only, leave `bsid` empty.
-- "Failed to open Test Session" → Verify token validity, network access, and the `x-sl-server` claim.
-- "No active build session for labId" → Ensure the Lab has an active build session for the given stage.
-- Selenium JS errors → Ensure your app pages load the SeaLights Browser Agent (`window.$SealightsAgent`).
+- "Listener disabled: Stage name is required" -> provide `stagename` as the third argument.
+- "Either 'bsid' or 'labId' must be provided" -> pass at least one; for `labid` only, leave `bsid` empty.
+- "Failed to open Test Session" -> verify token validity, network access, and the `x-sl-server` claim.
+- "No active build session for labId" -> ensure the lab has an active build session for the given stage.
+- Selenium JS errors -> ensure your app pages load the SeaLights Browser Agent (`window.$SealightsAgent`).
 
 ### File locations
-- Listener source: `robot/SLListener.py`
-- Test suite: `robot/tests/test_sl_listener.py`
-- This guide: `robot/SLListener.md`
+- Listener source: `sl_python_robot/SLListener.py`
+- Test suite: `sl_python_robot/tests/test_sl_listener.py`
+- Dependency list: `sl_python_robot/requirements.txt`
 
 ### Running tests
 
 ```bash
-cd robot
+cd sl_python_robot
 python3 -m pytest tests/test_sl_listener.py -v
 ```
 
 The test suite covers:
-- Initialization with various combinations of bsid/labid/stagename
-- Tag-based test identification (`_get_test_identifier`)
-- Excluded tests matching (by name vs by tag)
-- Build results aggregation (with and without tags)
-- API integration with mocked responses
+- Initialization with and without `testprojectid`
+- Header and request payload handling for `testProjectId`
+- `labid` resolution query parameter behavior

--- a/robot-custom-integration/sl_python_robot/SLListener.py
+++ b/robot-custom-integration/sl_python_robot/SLListener.py
@@ -1,8 +1,6 @@
 import functools
 import os
 import uuid
-from collections import Counter
-from itertools import groupby
 
 os.environ["OTEL_METRICS_EXPORTER"] = "none"
 os.environ["OTEL_TRACES_EXPORTER"] = "none"
@@ -29,7 +27,7 @@ TEST_STATUS_MAP = {"FAIL": "failed", "SKIP": "skipped"}
 class SLListener:
     ROBOT_LISTENER_API_VERSION = 3
 
-    def __init__(self, sltoken, bsid=None, stagename=None, labid=None, use_tags=False):
+    def __init__(self, sltoken, bsid=None, stagename=None, labid=None, testprojectid=None):
         self.token = sltoken
         self.base_url = self.extract_sl_endpoint()
         self.bsid = bsid
@@ -41,7 +39,6 @@ class SLListener:
         self.agent_id = str(uuid.uuid4())
         self.enabled = True
         self.disabled_reason = ""
-        self.use_tags = use_tags
 
         # Validate that at least one of bsid or labId is provided
         if not self.bsid and not self.labid:
@@ -54,6 +51,10 @@ class SLListener:
             print(
                 f"{SEALIGHTS_LOG_TAG} Both 'bsId' and 'labId' provided; using 'labId' ({self.labid})."
             )
+
+        self.test_project_id = testprojectid
+        if self.test_project_id:
+            print(f"{SEALIGHTS_LOG_TAG} Using testProjectId: {self.test_project_id}")
 
         if not self.stage_name:
             self.enabled = False
@@ -85,12 +86,12 @@ class SLListener:
         self.end_test_session()
 
     def start_test(self, data, result):
-        test_name = self.get_encoded_test_name(self._get_test_identifier(data))
+        test_name = self.get_encoded_test_name(data.name)
         self.try_instrument_selenium(test_name, self.test_session_id)
         self.start_span(test_name)
 
     def end_test(self, data, result):
-        test_name = self.get_encoded_test_name(self._get_test_identifier(data))
+        test_name = self.get_encoded_test_name(data.name)
         test_span = self.spans.get(test_name)
         if test_span:
             context.detach(test_span["token"])
@@ -107,6 +108,8 @@ class SLListener:
             "testStage": self.stage_name,
             "bsid": self.bsid,
         }
+        if self.test_project_id:
+            initialize_session_request["testProjectId"] = self.test_project_id
         response = requests.post(
             f"{self.base_url}/v1/test-sessions",
             json=initialize_session_request,
@@ -153,6 +156,8 @@ class SLListener:
         url = f"{api_endpoint}/v1/lab-ids/{self.labid}/build-sessions/active"
         print(f"Resolving build session id from labId: {self.labid}")
         params = {"agentId": self.agent_id, "testStage": self.stage_name}
+        if self.test_project_id:
+            params["testProjectId"] = self.test_project_id
         try:
             response = requests.get(url, headers=self.get_header(), params=params, timeout=30)
             if response.status_code == 200:
@@ -188,13 +193,12 @@ class SLListener:
         all_tests = set()
         for test in suite.tests:
             try:
-                test_identifier = self._get_test_identifier(test)
                 print(f"{SEALIGHTS_LOG_TAG} Processing Test Case: {test}")
-                all_tests.add(test_identifier)
-                if test_identifier not in self.excluded_tests:
-                    print(f"{SEALIGHTS_LOG_TAG} Test {test_identifier} is not excluded")
+                all_tests.add(test.name)
+                if test.name not in self.excluded_tests:
+                    print(f"{SEALIGHTS_LOG_TAG} Test {test.name} is not excluded")
                     continue
-                print(f"{SEALIGHTS_LOG_TAG} Marking test {test_identifier} as skipped")
+                print(f"{SEALIGHTS_LOG_TAG} Marking test {test.name} as skipped")
                 if not hasattr(test, "body"):
                     print(
                         f"{SEALIGHTS_LOG_TAG} Test {test.name} has no body, adding Skip keyword manually"
@@ -219,12 +223,6 @@ class SLListener:
 
     def build_test_results(self, result):
         # Collect and report test results to SeaLights including start and end time
-        if self.use_tags:
-            return self._build_test_results_with_tags(result)
-        return self._build_test_results_default(result)
-
-    def _build_test_results_default(self, result):
-        """Build test results without tag grouping (original behavior)."""
         tests = []
         for test in result.tests:
             test_status = TEST_STATUS_MAP.get(test.status, "passed")
@@ -239,35 +237,6 @@ class SLListener:
                 }
             )
         return tests
-
-    def _build_test_results_with_tags(self, result):
-        """Build test results with tag-based grouping and aggregation."""
-        test_results = []
-        sorted_tests = sorted(
-            result.tests, key=lambda test: self._get_test_identifier(test)
-        )
-        results = groupby(sorted_tests, key=lambda test: self._get_test_identifier(test))
-
-        for test_name, tests in results:
-            tests = list(tests)
-            start_times_ms, end_times_ms, test_statuses = self._extract_times_and_statuses(
-                tests
-            )
-            # Aggregate timing: earliest start, latest end
-            start_ms = min(start_times_ms)
-            end_ms = max(end_times_ms)
-            # Aggregate status: all skipped → skipped, any failed → failed, otherwise → passed
-            status_count = Counter(test_statuses)
-            if status_count.get("skipped", 0) == len(tests):
-                test_status = "skipped"
-            elif status_count.get("failed", 0) > 0:
-                test_status = "failed"
-            else:
-                test_status = "passed"
-            test_results.append(
-                {"name": test_name, "status": test_status, "start": start_ms, "end": end_ms}
-            )
-        return test_results
 
     def send_test_results(self, test_results):
         if not test_results:
@@ -309,10 +278,13 @@ class SLListener:
     # --- Generic helpers ---
 
     def get_header(self):
-        return {
+        headers = {
             "Authorization": f"Bearer {self.token}",
             "Content-Type": "application/json",
         }
+        if self.test_project_id:
+            headers["x-sl-testprojectid"] = self.test_project_id
+        return headers
 
     def get_session_url(self):
         return f"{self.base_url}/v1/test-sessions/{self.test_session_id}"
@@ -332,25 +304,6 @@ class SLListener:
 
     def get_encoded_test_name(self, test_name):
         return quote(test_name, safe="")
-
-    def _get_test_identifier(self, test):
-        """Returns the first tag if use_tags is enabled and tags exist, otherwise returns test.name."""
-        if self.use_tags and hasattr(test, 'tags') and len(test.tags) > 0:
-            return test.tags[0]
-        return test.name
-
-    def _extract_times_and_statuses(self, tests):
-        """Extracts timing and status data from a list of tests for aggregation."""
-        data = map(
-            lambda test: (
-                self.get_epoch_timestamp(test.starttime),
-                self.get_epoch_timestamp(test.endtime),
-                TEST_STATUS_MAP.get(test.status, "passed"),
-            ),
-            tests,
-        )
-        start_times_ms, end_times_ms, test_statuses = zip(*data)
-        return start_times_ms, end_times_ms, test_statuses
 
 
 def selenium_get_url(test_name, test_session_id):

--- a/robot-custom-integration/sl_python_robot/tests/test_sl_listener.py
+++ b/robot-custom-integration/sl_python_robot/tests/test_sl_listener.py
@@ -1,76 +1,30 @@
 """
-Test suite for SLListener - Robot Framework SeaLights integration.
+Tests for the example SLListener aligned with the Python agent listener.
 
-Tests cover:
-- Initialization with various combinations of bsid/labid/stagename
-- Tag-based test identification (_get_test_identifier)
-- Excluded tests matching (by name vs by tag)
-- Build results aggregation (with and without tags)
-- API integration with mocked responses
+All HTTP calls and JWT decoding are mocked so these tests run with no
+network or token dependencies.
 """
 
-import sys
 import os
-import pytest
+import sys
 from unittest.mock import MagicMock, patch
 
-# Add parent directory to path so we can import SLListener
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+from SLListener import SLListener
 
-# --- Mock dependencies before importing SLListener ---
-
-
-@pytest.fixture(autouse=True)
-def mock_dependencies():
-    """Mock external dependencies before importing SLListener."""
-    # Create mock modules
-    mock_jwt = MagicMock()
-    mock_jwt.decode = MagicMock(
-        return_value={"x-sl-server": "https://example.sealights.co/api"}
-    )
-
-    mock_requests = MagicMock()
-
-    mock_trace = MagicMock()
-    mock_context = MagicMock()
-    mock_baggage = MagicMock()
-    mock_otel = MagicMock()
-    mock_otel.trace = mock_trace
-    mock_otel.context = mock_context
-    mock_otel.baggage = mock_baggage
-
-    # Patch sys.modules before import
-    with patch.dict(
-        sys.modules,
-        {
-            "jwt": mock_jwt,
-            "requests": mock_requests,
-            "opentelemetry": mock_otel,
-            "opentelemetry.trace": mock_trace,
-            "opentelemetry.context": mock_context,
-            "opentelemetry.baggage": mock_baggage,
-        },
-    ):
-        # Force reimport
-        if "SLListener" in sys.modules:
-            del sys.modules["SLListener"]
-
-        yield {
-            "jwt": mock_jwt,
-            "requests": mock_requests,
-            "trace": mock_trace,
-            "context": mock_context,
-            "baggage": mock_baggage,
-        }
+FAKE_TOKEN = "fake.jwt.token"
+MOCK_JWT_PAYLOAD = {"x-sl-server": "https://test.sealights.io/api"}
 
 
-# --- Mock Helpers ---
+def _make_listener(**overrides):
+    defaults = dict(sltoken=FAKE_TOKEN, bsid="bsid-1", stagename="CI")
+    defaults.update(overrides)
+    with patch("SLListener.jwt.decode", return_value=MOCK_JWT_PAYLOAD):
+        return SLListener(**defaults)
 
 
 class MockBody:
-    """Mock Robot Framework test body."""
-
     def __init__(self):
         self._keywords = []
 
@@ -85,18 +39,14 @@ class MockBody:
 
 
 class MockTest:
-    """Mock Robot Framework test object."""
-
     def __init__(
         self,
         name,
-        tags=None,
         status="PASS",
         starttime="20240101 10:00:00.000",
         endtime="20240101 10:00:01.000",
     ):
         self.name = name
-        self.tags = tags or []
         self.status = status
         self.starttime = starttime
         self.endtime = endtime
@@ -109,16 +59,12 @@ class MockTest:
 
 
 class MockSuite:
-    """Mock Robot Framework suite object."""
-
     def __init__(self, tests=None):
         self.tests = tests or []
         self.longname = "MockSuite"
 
 
 class MockResult:
-    """Mock Robot Framework result object."""
-
     def __init__(
         self,
         tests=None,
@@ -130,558 +76,154 @@ class MockResult:
         self.endtime = endtime
 
 
-# --- Fixtures ---
-
-
-@pytest.fixture
-def listener_with_bsid(mock_dependencies):
-    """Create a listener with bsid only."""
-    from SLListener import SLListener
-
-    return SLListener(
-        sltoken="mock.token", bsid="test-bsid-123", stagename="unit-tests"
-    )
-
-
-@pytest.fixture
-def listener_with_labid(mock_dependencies):
-    """Create a listener with labid only."""
-    from SLListener import SLListener
-
-    return SLListener(
-        sltoken="mock.token", labid="test-labid-456", stagename="unit-tests"
-    )
-
-
-@pytest.fixture
-def listener_with_tags(mock_dependencies):
-    """Create a listener with use_tags=True."""
-    from SLListener import SLListener
-
-    return SLListener(
-        sltoken="mock.token",
-        bsid="test-bsid-123",
-        stagename="unit-tests",
-        use_tags=True,
-    )
-
-
-# --- Initialization Tests ---
-
-
-class TestSLListenerInit:
-    """Tests for SLListener initialization."""
-
-    def test_init_with_bsid_only(self, mock_dependencies):
-        """Test initialization with bsid provided, no labId - should enable."""
-        from SLListener import SLListener
-
-        listener = SLListener(
-            sltoken="mock.token", bsid="test-bsid", stagename="test-stage"
-        )
-        assert listener.enabled is True
-        assert listener.bsid == "test-bsid"
-        assert listener.labid is None
-
-    def test_init_with_labid_only(self, mock_dependencies):
-        """Test initialization with labId provided, no bsid - should enable."""
-        from SLListener import SLListener
-
-        listener = SLListener(
-            sltoken="mock.token", labid="test-labid", stagename="test-stage"
-        )
-        assert listener.enabled is True
-        assert listener.labid == "test-labid"
-        assert listener.bsid is None
-
-    def test_init_with_both_bsid_and_labid(self, mock_dependencies, capsys):
-        """Test initialization with both bsid and labId - should log message about using labId."""
-        from SLListener import SLListener
-
-        listener = SLListener(
-            sltoken="mock.token",
-            bsid="test-bsid",
-            labid="test-labid",
-            stagename="test-stage",
-        )
-        assert listener.enabled is True
-        captured = capsys.readouterr()
-        assert "labId" in captured.out
-
-    def test_init_without_bsid_or_labid(self, mock_dependencies):
-        """Test initialization without bsid or labId - should disable."""
-        from SLListener import SLListener
-
-        listener = SLListener(sltoken="mock.token", stagename="test-stage")
-        assert listener.enabled is False
-        assert "Either 'bsid' or 'labId' must be provided" in listener.disabled_reason
-
-    def test_init_without_stagename(self, mock_dependencies):
-        """Test initialization without stagename - should disable."""
-        from SLListener import SLListener
-
-        listener = SLListener(sltoken="mock.token", bsid="test-bsid")
-        assert listener.enabled is False
-        assert "Stage name is required" in listener.disabled_reason
-
-    def test_init_use_tags_default_false(self, mock_dependencies):
-        """Test that use_tags defaults to False."""
-        from SLListener import SLListener
-
-        listener = SLListener(
-            sltoken="mock.token", bsid="test-bsid", stagename="test-stage"
-        )
-        assert listener.use_tags is False
-
-    def test_init_use_tags_true(self, mock_dependencies):
-        """Test initialization with use_tags=True."""
-        from SLListener import SLListener
-
-        listener = SLListener(
-            sltoken="mock.token",
-            bsid="test-bsid",
-            stagename="test-stage",
-            use_tags=True,
-        )
-        assert listener.use_tags is True
-
-
-# --- Test Identifier Tests ---
-
-
-class TestGetTestIdentifier:
-    """Tests for _get_test_identifier method."""
-
-    def test_get_test_identifier_without_tags_mode(self, listener_with_bsid):
-        """Test that use_tags=False returns test.name."""
-        test = MockTest(name="TestLogin", tags=["Login", "Smoke"])
-        result = listener_with_bsid._get_test_identifier(test)
-        assert result == "TestLogin"
-
-    def test_get_test_identifier_with_tags_mode_has_tags(self, listener_with_tags):
-        """Test that use_tags=True with tags returns first tag."""
-        test = MockTest(name="TestLogin_Chrome", tags=["Login", "Smoke"])
-        result = listener_with_tags._get_test_identifier(test)
-        assert result == "Login"
-
-    def test_get_test_identifier_with_tags_mode_no_tags(self, listener_with_tags):
-        """Test that use_tags=True without tags falls back to test.name."""
-        test = MockTest(name="TestLogin", tags=[])
-        result = listener_with_tags._get_test_identifier(test)
-        assert result == "TestLogin"
-
-    def test_get_test_identifier_with_tags_mode_empty_tags_list(
-        self, listener_with_tags
-    ):
-        """Test fallback when tags list is empty."""
-        test = MockTest(name="MyTest", tags=[])
-        result = listener_with_tags._get_test_identifier(test)
-        assert result == "MyTest"
-
-
-# --- Excluded Tests Tests ---
-
-
-class TestExcludedTests:
-    """Tests for excluded tests matching."""
-
-    def test_mark_tests_skipped_by_name(self, listener_with_bsid):
-        """Test that use_tags=False matches excluded tests by test.name."""
-        test1 = MockTest(name="TestLogin")
-        test2 = MockTest(name="TestLogout")
-        test3 = MockTest(name="TestDashboard")
-        suite = MockSuite(tests=[test1, test2, test3])
-
-        listener_with_bsid.excluded_tests = {"TestLogin", "TestDashboard"}
-        listener_with_bsid.mark_tests_to_be_skipped(suite)
-
-        # TestLogin and TestDashboard should have SKIP keyword added
-        assert "SKIP" in test1.body._keywords
-        assert "SKIP" not in test2.body._keywords
-        assert "SKIP" in test3.body._keywords
-
-    def test_mark_tests_skipped_by_tag(self, listener_with_tags):
-        """Test that use_tags=True matches excluded tests by first tag."""
-        test1 = MockTest(name="TestLogin_Chrome", tags=["Login"])
-        test2 = MockTest(name="TestLogin_Firefox", tags=["Login"])
-        test3 = MockTest(name="TestCheckout", tags=["Checkout"])
-        suite = MockSuite(tests=[test1, test2, test3])
-
-        listener_with_tags.excluded_tests = {"Login"}
-        listener_with_tags.mark_tests_to_be_skipped(suite)
-
-        # Both Login tests should be skipped, Checkout should not
-        assert "SKIP" in test1.body._keywords
-        assert "SKIP" in test2.body._keywords
-        assert "SKIP" not in test3.body._keywords
-
-    def test_no_tests_excluded(self, listener_with_bsid):
-        """Test that empty excluded list doesn't skip any tests."""
-        test1 = MockTest(name="TestLogin")
-        test2 = MockTest(name="TestLogout")
-        suite = MockSuite(tests=[test1, test2])
-
-        listener_with_bsid.excluded_tests = set()
-        listener_with_bsid.mark_tests_to_be_skipped(suite)
-
-        assert "SKIP" not in test1.body._keywords
-        assert "SKIP" not in test2.body._keywords
-
-    def test_mark_tests_skipped_mixed_tags_no_tags(self, listener_with_tags):
-        """Test mixed scenario: some tests have tags, some don't."""
-        test1 = MockTest(name="TestLogin_Chrome", tags=["Login"])
-        test2 = MockTest(name="TestWithoutTag", tags=[])  # Falls back to name
-        suite = MockSuite(tests=[test1, test2])
-
-        listener_with_tags.excluded_tests = {"Login", "TestWithoutTag"}
-        listener_with_tags.mark_tests_to_be_skipped(suite)
-
-        assert "SKIP" in test1.body._keywords
-        assert "SKIP" in test2.body._keywords
-
-
-# --- Build Results Tests ---
-
-
-class TestBuildTestResults:
-    """Tests for build_test_results method."""
-
-    def test_build_results_without_tags(self, listener_with_bsid):
-        """Test default mode returns individual results."""
-        test1 = MockTest(name="Test1", status="PASS")
-        test2 = MockTest(name="Test2", status="FAIL")
-        result = MockResult(tests=[test1, test2])
-
-        results = listener_with_bsid.build_test_results(result)
-
-        assert len(results) == 2
-        assert results[0]["name"] == "Test1"
-        assert results[1]["name"] == "Test2"
-
-    def test_build_results_with_tags_grouping(self, listener_with_tags):
-        """Test tags mode groups results by tag."""
-        test1 = MockTest(
-            name="TestLogin_Chrome",
-            tags=["Login"],
-            status="PASS",
-            starttime="20240101 10:00:00.000",
-            endtime="20240101 10:00:01.000",
-        )
-        test2 = MockTest(
-            name="TestLogin_Firefox",
-            tags=["Login"],
-            status="PASS",
-            starttime="20240101 10:00:02.000",
-            endtime="20240101 10:00:03.000",
-        )
-        test3 = MockTest(
-            name="TestCheckout",
-            tags=["Checkout"],
-            status="PASS",
-            starttime="20240101 10:00:04.000",
-            endtime="20240101 10:00:05.000",
-        )
-        result = MockResult(tests=[test1, test2, test3])
-
-        results = listener_with_tags.build_test_results(result)
-
-        assert len(results) == 2
-        names = [r["name"] for r in results]
-        assert "Login" in names
-        assert "Checkout" in names
-
-    def test_build_results_aggregation_all_passed(self, listener_with_tags):
-        """Test aggregation: all same tag passed → passed."""
-        test1 = MockTest(name="Test1", tags=["Login"], status="PASS")
-        test2 = MockTest(name="Test2", tags=["Login"], status="PASS")
-        result = MockResult(tests=[test1, test2])
-
-        results = listener_with_tags.build_test_results(result)
-
-        assert len(results) == 1
-        assert results[0]["name"] == "Login"
-        assert results[0]["status"] == "passed"
-
-    def test_build_results_aggregation_any_failed(self, listener_with_tags):
-        """Test aggregation: any failed → failed."""
-        test1 = MockTest(name="Test1", tags=["Login"], status="PASS")
-        test2 = MockTest(name="Test2", tags=["Login"], status="FAIL")
-        test3 = MockTest(name="Test3", tags=["Login"], status="PASS")
-        result = MockResult(tests=[test1, test2, test3])
-
-        results = listener_with_tags.build_test_results(result)
-
-        assert len(results) == 1
-        assert results[0]["name"] == "Login"
-        assert results[0]["status"] == "failed"
-
-    def test_build_results_aggregation_all_skipped(self, listener_with_tags):
-        """Test aggregation: all skipped → skipped."""
-        test1 = MockTest(name="Test1", tags=["Login"], status="SKIP")
-        test2 = MockTest(name="Test2", tags=["Login"], status="SKIP")
-        result = MockResult(tests=[test1, test2])
-
-        results = listener_with_tags.build_test_results(result)
-
-        assert len(results) == 1
-        assert results[0]["name"] == "Login"
-        assert results[0]["status"] == "skipped"
-
-    def test_build_results_aggregation_timing(self, listener_with_tags):
-        """Test aggregation uses min(start), max(end)."""
-        test1 = MockTest(
-            name="Test1",
-            tags=["Login"],
-            status="PASS",
-            starttime="20240101 10:00:05.000",  # Later start
-            endtime="20240101 10:00:06.000",
-        )
-        test2 = MockTest(
-            name="Test2",
-            tags=["Login"],
-            status="PASS",
-            starttime="20240101 10:00:00.000",  # Earlier start
-            endtime="20240101 10:00:10.000",  # Later end
-        )
-        result = MockResult(tests=[test1, test2])
-
-        results = listener_with_tags.build_test_results(result)
-
-        assert len(results) == 1
-        # Should use the earlier start time (10:00:00)
-        expected_start = listener_with_tags.get_epoch_timestamp("20240101 10:00:00.000")
-        # Should use the later end time (10:00:10)
-        expected_end = listener_with_tags.get_epoch_timestamp("20240101 10:00:10.000")
-        assert results[0]["start"] == expected_start
-        assert results[0]["end"] == expected_end
-
-    def test_build_results_mixed_passed_skipped(self, listener_with_tags):
-        """Test aggregation: mixed passed and skipped → passed (not all skipped)."""
-        test1 = MockTest(name="Test1", tags=["Login"], status="PASS")
-        test2 = MockTest(name="Test2", tags=["Login"], status="SKIP")
-        result = MockResult(tests=[test1, test2])
-
-        results = listener_with_tags.build_test_results(result)
-
-        assert len(results) == 1
-        assert results[0]["status"] == "passed"
-
-
-# --- API Integration Tests ---
-
-
-class TestAPIIntegration:
-    """Tests for API integration with mocked responses."""
-
-    def test_resolve_bsid_from_labid_success(self, mock_dependencies):
-        """Test successful labId resolution returns bsid."""
-        from SLListener import SLListener
-
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {"buildSessionId": "resolved-bsid-789"}
-        mock_dependencies["requests"].get.return_value = mock_response
-
-        listener = SLListener(
-            sltoken="mock.token", labid="test-labid", stagename="test-stage"
-        )
-        listener.resolve_bsid_from_labid()
-
-        assert listener.bsid == "resolved-bsid-789"
-        assert listener.enabled is True
-
-    def test_resolve_bsid_from_labid_404(self, mock_dependencies):
-        """Test 404 response disables listener."""
-        from SLListener import SLListener
-
-        mock_response = MagicMock()
-        mock_response.status_code = 404
-        mock_dependencies["requests"].get.return_value = mock_response
-
-        listener = SLListener(
-            sltoken="mock.token", labid="test-labid", stagename="test-stage"
-        )
-        listener.resolve_bsid_from_labid()
-
-        assert listener.enabled is False
-        assert "No active build session found" in listener.disabled_reason
-
-    def test_resolve_bsid_from_labid_500(self, mock_dependencies):
-        """Test 500 response disables listener."""
-        from SLListener import SLListener
-
-        mock_response = MagicMock()
-        mock_response.status_code = 500
-        mock_dependencies["requests"].get.return_value = mock_response
-
-        listener = SLListener(
-            sltoken="mock.token", labid="test-labid", stagename="test-stage"
-        )
-        listener.resolve_bsid_from_labid()
-
-        assert listener.enabled is False
-        assert "Server error" in listener.disabled_reason
-
-    def test_create_test_session_success(self, mock_dependencies):
-        """Test successful session creation sets test_session_id."""
-        from SLListener import SLListener
-
-        mock_response = MagicMock()
-        mock_response.ok = True
-        mock_response.json.return_value = {"data": {"testSessionId": "session-123"}}
-        mock_dependencies["requests"].post.return_value = mock_response
-
-        listener = SLListener(
-            sltoken="mock.token", bsid="test-bsid", stagename="test-stage"
-        )
-        listener.create_test_session()
-
-        assert listener.test_session_id == "session-123"
-        # Verify correct payload was sent
-        call_args = mock_dependencies["requests"].post.call_args
-        payload = call_args[1]["json"]
-        assert payload["bsid"] == "test-bsid"
-        assert payload["testStage"] == "test-stage"
-
-    def test_create_test_session_failure(self, mock_dependencies, capsys):
-        """Test failed session creation logs error."""
-        from SLListener import SLListener
-
-        mock_response = MagicMock()
-        mock_response.ok = False
-        mock_response.status_code = 500
-        mock_dependencies["requests"].post.return_value = mock_response
-
-        listener = SLListener(
-            sltoken="mock.token", bsid="test-bsid", stagename="test-stage"
-        )
-        listener.create_test_session()
-
-        assert listener.test_session_id is None
-        captured = capsys.readouterr()
-        assert "Failed to open Test Session" in captured.out
-
-    def test_get_excluded_tests_success(self, mock_dependencies):
-        """Test successful retrieval of excluded tests."""
-        from SLListener import SLListener
-
-        mock_response = MagicMock()
-        mock_response.ok = True
-        mock_response.status_code = 200
-        mock_response.json.return_value = {"data": ["Test1", "Test2", "Test3"]}
-        mock_dependencies["requests"].get.return_value = mock_response
-
-        listener = SLListener(
-            sltoken="mock.token", bsid="test-bsid", stagename="test-stage"
-        )
-        listener.test_session_id = "session-123"
-        excluded = listener.get_excluded_tests()
-
-        assert excluded == ["Test1", "Test2", "Test3"]
-        # Verify correct endpoint was called
-        call_args = mock_dependencies["requests"].get.call_args
-        assert "session-123" in call_args[0][0]
-        assert "exclude-tests" in call_args[0][0]
-
-    def test_get_excluded_tests_empty(self, mock_dependencies):
-        """Test empty excluded tests list."""
-        from SLListener import SLListener
-
-        mock_response = MagicMock()
-        mock_response.ok = True
-        mock_response.status_code = 200
-        mock_response.json.return_value = {"data": []}
-        mock_dependencies["requests"].get.return_value = mock_response
-
-        listener = SLListener(
-            sltoken="mock.token", bsid="test-bsid", stagename="test-stage"
-        )
-        listener.test_session_id = "session-123"
-        excluded = listener.get_excluded_tests()
-
-        assert excluded == []
-
-    def test_send_test_results_success(self, mock_dependencies):
-        """Test successful sending of test results."""
-        from SLListener import SLListener
-
-        mock_response = MagicMock()
-        mock_response.ok = True
-        mock_dependencies["requests"].post.return_value = mock_response
-
-        listener = SLListener(
-            sltoken="mock.token", bsid="test-bsid", stagename="test-stage"
-        )
-        listener.test_session_id = "session-123"
-        test_results = [{"name": "Test1", "status": "passed", "start": 0, "end": 1000}]
-
-        listener.send_test_results(test_results)
-
-        # Verify post was called with correct URL and data
-        mock_dependencies["requests"].post.assert_called_once()
-        call_args = mock_dependencies["requests"].post.call_args
-        assert "session-123" in call_args[0][0]  # URL contains session ID
-        assert call_args[1]["json"] == test_results  # Correct payload sent
-
-    def test_end_test_session(self, mock_dependencies):
-        """Test ending test session."""
-        from SLListener import SLListener
-
-        mock_dependencies["requests"].delete.return_value = MagicMock()
-
-        listener = SLListener(
-            sltoken="mock.token", bsid="test-bsid", stagename="test-stage"
-        )
-        listener.test_session_id = "session-123"
-        listener.end_test_session()
-
-        assert listener.test_session_id == ""
-        mock_dependencies["requests"].delete.assert_called_once()
-        call_args = mock_dependencies["requests"].delete.call_args
-        assert "session-123" in call_args[0][0]  # URL contains session ID
-
-
-# --- Helper Method Tests ---
-
-
-class TestHelperMethods:
-    """Tests for helper methods."""
-
-    def test_get_epoch_timestamp(self, listener_with_bsid):
-        """Test timestamp conversion."""
-        timestamp = listener_with_bsid.get_epoch_timestamp("20240101 10:00:00.000")
-        # 2024-01-01 10:00:00 UTC = 1704103200000 ms (assuming local time interpretation)
-        # Verify it's a reasonable timestamp (after year 2000, before year 2100)
-        assert isinstance(timestamp, int)
-        assert 946684800000 < timestamp < 4102444800000  # Between 2000 and 2100
-        # Verify two different timestamps produce different results
-        timestamp2 = listener_with_bsid.get_epoch_timestamp("20240101 10:00:01.000")
-        assert timestamp2 == timestamp + 1000  # 1 second = 1000ms difference
-
-    def test_get_encoded_test_name(self, listener_with_bsid):
-        """Test URL encoding of test names."""
-        result = listener_with_bsid.get_encoded_test_name("Test With Spaces")
-        assert " " not in result
-        assert result == "Test%20With%20Spaces"
-
-    def test_get_encoded_test_name_special_chars(self, listener_with_bsid):
-        """Test URL encoding of special characters."""
-        result = listener_with_bsid.get_encoded_test_name("Test/With/Slashes")
-        assert result == "Test%2FWith%2FSlashes"
-
-    def test_extract_sl_endpoint(self, mock_dependencies):
-        """Test endpoint extraction from token."""
-        from SLListener import SLListener
-
-        listener = SLListener(
-            sltoken="mock.token", bsid="test-bsid", stagename="test-stage"
-        )
-        # Mock returns "https://example.sealights.co/api", should become "https://example.sealights.co/sl-api"
-        assert listener.base_url == "https://example.sealights.co/sl-api"
-
-    def test_get_header(self, listener_with_bsid):
-        """Test header generation."""
-        headers = listener_with_bsid.get_header()
+class TestInit:
+    def test_stores_test_project_id(self):
+        listener = _make_listener(testprojectid="my-project")
+        assert listener.test_project_id == "my-project"
+
+    def test_test_project_id_defaults_to_none(self):
+        listener = _make_listener()
+        assert listener.test_project_id is None
+
+
+class TestGetHeader:
+    def test_includes_testprojectid_when_set(self):
+        listener = _make_listener(testprojectid="proj-123")
+        headers = listener.get_header()
+        assert headers["x-sl-testprojectid"] == "proj-123"
         assert "Authorization" in headers
-        assert headers["Authorization"].startswith("Bearer ")
-        assert headers["Content-Type"] == "application/json"
+        assert "Content-Type" in headers
+
+    def test_excludes_testprojectid_when_none(self):
+        listener = _make_listener()
+        headers = listener.get_header()
+        assert "x-sl-testprojectid" not in headers
+
+    def test_excludes_testprojectid_when_empty_string(self):
+        listener = _make_listener(testprojectid="")
+        headers = listener.get_header()
+        assert "x-sl-testprojectid" not in headers
+
+
+class TestCreateTestSession:
+    @patch("SLListener.requests")
+    def test_body_includes_testprojectid(self, mock_requests):
+        mock_requests.post.return_value = MagicMock(
+            ok=True, json=lambda: {"data": {"testSessionId": "sess-1"}}
+        )
+        listener = _make_listener(testprojectid="proj-123")
+        listener.create_test_session()
+
+        body = mock_requests.post.call_args.kwargs["json"]
+        assert body["testProjectId"] == "proj-123"
+
+    @patch("SLListener.requests")
+    def test_body_excludes_testprojectid_when_not_set(self, mock_requests):
+        mock_requests.post.return_value = MagicMock(
+            ok=True, json=lambda: {"data": {"testSessionId": "sess-1"}}
+        )
+        listener = _make_listener()
+        listener.create_test_session()
+
+        body = mock_requests.post.call_args.kwargs["json"]
+        assert "testProjectId" not in body
+
+    @patch("SLListener.requests")
+    def test_body_excludes_testprojectid_when_empty_string(self, mock_requests):
+        mock_requests.post.return_value = MagicMock(
+            ok=True, json=lambda: {"data": {"testSessionId": "sess-1"}}
+        )
+        listener = _make_listener(testprojectid="")
+        listener.create_test_session()
+
+        body = mock_requests.post.call_args.kwargs["json"]
+        assert "testProjectId" not in body
+
+    @patch("SLListener.requests")
+    def test_sends_testprojectid_header(self, mock_requests):
+        mock_requests.post.return_value = MagicMock(
+            ok=True, json=lambda: {"data": {"testSessionId": "sess-1"}}
+        )
+        listener = _make_listener(testprojectid="proj-123")
+        listener.create_test_session()
+
+        headers = mock_requests.post.call_args.kwargs["headers"]
+        assert headers["x-sl-testprojectid"] == "proj-123"
+
+
+class TestResolveBsidFromLabid:
+    @patch("SLListener.jwt.decode", return_value=MOCK_JWT_PAYLOAD)
+    @patch("SLListener.requests")
+    def test_includes_testprojectid_query_param(self, mock_requests, _mock_jwt):
+        mock_requests.get.return_value = MagicMock(
+            status_code=200, json=lambda: {"buildSessionId": "resolved-bsid"}
+        )
+        listener = _make_listener(labid="lab-1", testprojectid="proj-123")
+        listener.resolve_bsid_from_labid()
+
+        params = mock_requests.get.call_args.kwargs["params"]
+        assert params["testProjectId"] == "proj-123"
+
+    @patch("SLListener.jwt.decode", return_value=MOCK_JWT_PAYLOAD)
+    @patch("SLListener.requests")
+    def test_excludes_testprojectid_when_none(self, mock_requests, _mock_jwt):
+        mock_requests.get.return_value = MagicMock(
+            status_code=200, json=lambda: {"buildSessionId": "resolved-bsid"}
+        )
+        listener = _make_listener(labid="lab-1")
+        listener.resolve_bsid_from_labid()
+
+        params = mock_requests.get.call_args.kwargs["params"]
+        assert "testProjectId" not in params
+
+    @patch("SLListener.jwt.decode", return_value=MOCK_JWT_PAYLOAD)
+    @patch("SLListener.requests")
+    def test_sends_testprojectid_header(self, mock_requests, _mock_jwt):
+        mock_requests.get.return_value = MagicMock(
+            status_code=200, json=lambda: {"buildSessionId": "resolved-bsid"}
+        )
+        listener = _make_listener(labid="lab-1", testprojectid="proj-123")
+        listener.resolve_bsid_from_labid()
+
+        headers = mock_requests.get.call_args.kwargs["headers"]
+        assert headers["x-sl-testprojectid"] == "proj-123"
+
+
+class TestNameBasedBehavior:
+    def test_marks_excluded_tests_by_test_name(self):
+        listener = _make_listener()
+        test_login = MockTest(name="TestLogin")
+        test_logout = MockTest(name="TestLogout")
+        suite = MockSuite(tests=[test_login, test_logout])
+
+        listener.excluded_tests = {"TestLogin"}
+        listener.mark_tests_to_be_skipped(suite)
+
+        assert "SKIP" in test_login.body._keywords
+        assert "SKIP" not in test_logout.body._keywords
+
+    def test_build_test_results_reports_individual_test_names(self):
+        listener = _make_listener()
+        test_one = MockTest(name="Login_Chrome", status="PASS")
+        test_two = MockTest(name="Login_Firefox", status="FAIL")
+        result = MockResult(tests=[test_one, test_two])
+
+        test_results = listener.build_test_results(result)
+
+        assert len(test_results) == 2
+        assert test_results[0]["name"] == "Login_Chrome"
+        assert test_results[0]["status"] == "passed"
+        assert test_results[1]["name"] == "Login_Firefox"
+        assert test_results[1]["status"] == "failed"
+
+    @patch.object(SLListener, "try_instrument_selenium")
+    @patch.object(SLListener, "start_span")
+    def test_start_test_uses_encoded_test_name(self, mock_start_span, mock_instrument):
+        listener = _make_listener()
+        listener.test_session_id = "session-123"
+        test = MockTest(name="Test With Spaces")
+
+        listener.start_test(test, result=None)
+
+        mock_instrument.assert_called_once_with("Test%20With%20Spaces", "session-123")
+        mock_start_span.assert_called_once_with("Test%20With%20Spaces")


### PR DESCRIPTION
## Summary
- replace the example Robot listener's old tag-grouping contract with the current Python agent `testprojectid` behavior
- update the example test suite to cover `testProjectId` propagation plus name-based skip/result behavior
- refresh the example README to document the current listener arguments and migration away from the old fifth `use_tags` argument

## Test plan
- [x] `.venv/bin/python -m pytest sl_python_robot/tests/test_sl_listener.py -q`

Made with [Cursor](https://cursor.com)