### PR TITLE
[SLDEV-28240] fix(robot): move TIA lookup to v2 exclude-tests

### DIFF
--- a/behave-robot-playwright-browser/robot-test-runner/SLListener.py
+++ b/behave-robot-playwright-browser/robot-test-runner/SLListener.py
@@ -1,7 +1,9 @@
 import functools
+import math
 import os
 import socket
 import sys
+import time
 import uuid
 
 os.environ["OTEL_METRICS_EXPORTER"] = "none"
@@ -27,7 +29,7 @@ except ImportError:
     PlaywrightBrowserContext = None
 
 # Bump this string on every change to the listener.
-__version__ = "1.3.0"
+__version__ = "1.4.0"
 
 SL_TEST_LISTENER_TRACER = "sl-test-listener"
 tracer = trace.get_tracer(SL_TEST_LISTENER_TRACER)
@@ -88,6 +90,8 @@ class SLListener:
         self.bsid = bsid
         self.stage_name = stagename
         self.excluded_tests = set()
+        self.tia_resolved = False
+        self.tia_attempted = False
         self.test_session_id = None
         self.labid = labid
         self.test_project_id = testprojectid
@@ -101,9 +105,8 @@ class SLListener:
             self.enabled = False
             self.disabled_reason = "Either 'bsid' or 'labId' must be provided. SeaLights listener is disabled."
         elif self.bsid and self.labid:
-            # When both provided, labId will be used to resolve the active bsid
             _sl_log(
-                f"Both 'bsId' and 'labId' provided; using 'labId' ({self.labid}).",
+                f"Both 'bsId' and 'labId' provided; using the supplied bsId ('{self.bsid}') — labId ignored.",
                 level="WARNING",
             )
 
@@ -121,13 +124,13 @@ class SLListener:
         _sl_log(f"  PID       : {os.getpid()}")
         _sl_log(f"  Python    : {sys.version.split()[0]}")
         _sl_log(f"  Endpoint  : {self.base_url}")
-        _sl_log(f"  Stage     : {self.stage_name}")
+        _sl_log(f"  Stage     : {self.stage_name or '(missing — listener disabled)'}")
         _sl_log(f"  labId     : {self.labid or '(none)'}")
         _sl_log(f"  bsId      : {self.bsid or '(resolving from labId)'}")
         _sl_log(f"  agentId   : {self.agent_id}")
         _sl_log(f"  projId    : {self.test_project_id or '(none)'}")
         _sl_log(f"  LogLevel  : {os.environ.get('SL_LOG_LEVEL', 'INFO (default)')}")
-        _sl_log(f"─────────────────────────────────────────────────────────────────")
+        _sl_log("─────────────────────────────────────────────────────────────────")
         if not self.enabled:
             _sl_log(f"DISABLED: {self.disabled_reason}", level="WARNING")
 
@@ -151,31 +154,42 @@ class SLListener:
             return
 
         if not self.test_session_id:
-            _sl_log(f"No active session — opening new one")
+            _sl_log("No active session — opening new one")
             self.create_test_session()
-            self.excluded_tests = set(self.get_excluded_tests())
-            self.mark_tests_to_be_skipped(suite)
         else:
             _sl_log(f"Reusing existing session: {self.test_session_id}", level="DEBUG")
+
+        if not self.tia_resolved:
+            names, terminal = self.get_excluded_tests(poll=not self.tia_attempted)
+            self.tia_attempted = True
+            if terminal:
+                self.excluded_tests = set(names)
+                self.tia_resolved = True
+        self.mark_tests_to_be_skipped(suite)
 
     def end_suite(self, data, result):
         if not self.test_session_id:
             return
-        _sl_log(f"end_suite: '{result.longname}' | closing session {self.test_session_id}")
+        _sl_log(
+            f"end_suite: '{result.longname}' | closing session {self.test_session_id}"
+        )
         test_results = self.build_test_results(result)
         self.send_test_results(test_results)
         self.end_test_session()
 
     def start_test(self, data, result):
         test_name = self.get_encoded_test_name(data.name)
-        _sl_log(f"→ start_test: '{data.name}' | session: {self.test_session_id}")
+        _sl_log(
+            f"→ start_test: '{data.name}' | session: {self.test_session_id}",
+            level="DEBUG",
+        )
         self.try_instrument_selenium(test_name, self.test_session_id)
         self.try_instrument_playwright(test_name, self.test_session_id)
         self.start_span(test_name)
 
     def end_test(self, data, result):
         test_name = self.get_encoded_test_name(data.name)
-        _sl_log(f"← end_test:   '{data.name}' | {result.status}")
+        _sl_log(f"← end_test:   '{data.name}' | {result.status}", level="DEBUG")
         test_span = self.spans.get(test_name)
         if test_span:
             context.detach(test_span["token"])
@@ -194,13 +208,13 @@ class SLListener:
         }
         if self.test_project_id:
             initialize_session_request["testProjectId"] = self.test_project_id
+        _sl_log(f"Creating session with: {initialize_session_request}", level="DEBUG")
         response = requests.post(
             f"{self.base_url}/v1/test-sessions/test-stage",
             json=initialize_session_request,
             headers=self.get_header(),
             timeout=30,
         )
-        _sl_log(f"Creating session with: {initialize_session_request}", level="DEBUG")
         if not response.ok:
             _sl_log(
                 f"Failed to open Test Session (Error {response.status_code}), disabling Sealights Listener",
@@ -211,20 +225,113 @@ class SLListener:
             self.test_session_id = res["data"]["testSessionId"]
             _sl_log(f"Test session opened, testSessionId: {self.test_session_id}")
 
-    def get_excluded_tests(self):
-        excluded_tests = []
-        recommendations = requests.get(
-            f"{self.get_session_url()}/exclude-tests",
-            headers=self.get_header(),
-            timeout=30,
-        )
-        _sl_log(
-            f"Retrieving Recommendations: {'OK' if recommendations.ok else f'Error {recommendations.status_code}'}"
-        )
-        if recommendations.status_code == 200:
-            excluded_tests = recommendations.json()["data"]
-        _sl_log(f"{len(self.excluded_tests)} Skipped tests: {excluded_tests}")
-        return excluded_tests
+    def get_exclude_tests_url(self):
+        return f"{self.base_url}/v2/test-sessions/{self.test_session_id}/exclude-tests"
+
+    def _fetch_exclusions_once(self):
+        """Single GET against the v2 exclude-tests endpoint.
+
+        Returns (names, terminal, retryable). `retryable` is True only for a
+        200 response with status "notReady" — every other failure (transport
+        error, non-200, unparsable/non-dict body) is terminal-with-no-names
+        and non-retryable so the poll loop can break immediately (fail-open).
+        """
+        try:
+            response = requests.get(
+                self.get_exclude_tests_url(),
+                headers=self.get_header(),
+                timeout=30,
+            )
+        except requests.RequestException as e:
+            _sl_log(f"TIA: request failed — {e}", level="WARNING")
+            return [], False, False
+
+        if response.status_code != 200:
+            _sl_log(f"TIA: unexpected status {response.status_code}", level="WARNING")
+            return [], False, False
+
+        try:
+            body = response.json()
+        except ValueError as e:
+            _sl_log(f"TIA: failed to parse response — {e}", level="WARNING")
+            return [], False, False
+
+        if not isinstance(body, dict):
+            _sl_log("TIA: response body is not an object", level="WARNING")
+            return [], False, False
+
+        payload = body["data"] if "data" in body else body
+        metadata = payload.get("metadata") or {}
+        enabled = metadata.get("testSelectionEnabled")
+        status = metadata.get("status")
+
+        if enabled is True and status == "ready":
+            names = [
+                t["testName"]
+                for t in (payload.get("excludedTests") or [])
+                if isinstance(t, dict) and t.get("testName")
+            ]
+            _sl_log(f"TIA: enabled={enabled} status={status} → {len(names)} excluded")
+            return names, True, False
+
+        if enabled is True and status == "notReady":
+            _sl_log(f"TIA: enabled={enabled} status={status} → 0 excluded")
+            return [], False, True
+
+        _sl_log(f"TIA: enabled={enabled} status={status} → 0 excluded")
+        return [], True, False
+
+    def get_excluded_tests(self, poll=True):
+        if not self.test_session_id:
+            return [], False
+
+        timeout = self._read_positive_env("SL_TIA_POLLING_TIMEOUT_SEC", 60)
+        interval = self._read_positive_env("SL_TIA_POLLING_INTERVAL_SEC", 5)
+
+        if not poll or timeout == 0 or interval == 0:
+            names, terminal, _retryable = self._fetch_exclusions_once()
+            return names, terminal
+
+        deadline = time.monotonic() + timeout
+        names, terminal, retryable = self._fetch_exclusions_once()
+        retry_count = 0
+        while retryable and not terminal and time.monotonic() < deadline:
+            sleep_for = max(0, min(interval, deadline - time.monotonic()))
+            if sleep_for == 0:
+                break
+            retry_count += 1
+            _sl_log(
+                f"TIA notReady — retry {retry_count} in {sleep_for}s", level="DEBUG"
+            )
+            time.sleep(sleep_for)
+            names, terminal, retryable = self._fetch_exclusions_once()
+
+        if retryable and not terminal:
+            _sl_log(
+                "TIA: polling deadline reached while still notReady", level="WARNING"
+            )
+
+        return names, terminal
+
+    def _read_positive_env(self, name, default):
+        raw = os.environ.get(name)
+        if raw is None:
+            return default
+        try:
+            value = float(raw)
+        except (TypeError, ValueError):
+            _sl_log(
+                f"Invalid value for {name}={raw!r}; using default {default}",
+                level="WARNING",
+            )
+            return default
+        if not math.isfinite(value) or value < 0:
+            _sl_log(
+                f"Invalid value for {name}={raw!r}; using default {default}",
+                level="WARNING",
+            )
+            return default
+        return value
 
     def resolve_bsid_from_labid(self):
         """
@@ -258,12 +365,14 @@ class SLListener:
             self.disabled_reason = (
                 f"Network error while resolving labId {self.labid}: {str(e)}"
             )
+            self.enabled = False
+            return
         if response.status_code == 404:
             self.disabled_reason = f"No active build session found for labId '{self.labid}'. Sealights Listener is disabled."
         elif response.status_code == 500:
-            self.disabled_reason = f"{SEALIGHTS_LOG_TAG} Server error while resolving bsid (HTTP 500). Sealights Listener is disabled."
+            self.disabled_reason = "Server error while resolving bsid (HTTP 500). Sealights Listener is disabled."
         else:
-            self.disabled_reason = f"{SEALIGHTS_LOG_TAG} Failed to resolve active build session (Error {response.status_code}). Sealights Listener is disabled."
+            self.disabled_reason = f"Failed to resolve active build session (Error {response.status_code}). Sealights Listener is disabled."
         self.enabled = False
         return
 

--- a/robot-custom-integration/sl_python_robot/SLListener.md
+++ b/robot-custom-integration/sl_python_robot/SLListener.md
@@ -66,14 +66,19 @@ robot --listener "/path/to/repo/robot/SLListener.py:${SL_TOKEN}::CI Tests:${LAB_
 
 ### How endpoints are determined
 - The listener decodes the JWT (without signature verification) and reads `x-sl-server`, e.g. `https://your.sl.server/api`.
-- For Test Session APIs it uses the `sl-api` base by converting `/api` → `/sl-api`.
-- When resolving `bsid` from `labid`, it calls `GET /v1/lab-ids/{labId}/build-sessions/active` on the API base with query params `agentId`, `testStage`, and `testProjectId` (when provided).
+- Test Sessions (create/results/close) and the v2 exclude-tests lookup use the `sl-api` base, by converting `/api` → `/sl-api`.
+- When resolving `bsid` from `labid`, it calls `GET /v1/lab-ids/{labId}/build-sessions/active` on the **API base** (not `sl-api`) with query params `agentId`, `testStage`, and `testProjectId` (when provided).
 
 ### Test selection behavior
-- On suite start, the listener calls `GET /v1/test-sessions/{id}/exclude-tests`.
-- Test names returned from this endpoint are marked as `SKIP` before execution.
+- On the first suite of the run, the listener calls `GET /v2/test-sessions/{id}/exclude-tests` and applies the result once `metadata.testSelectionEnabled` is `true` and `metadata.status` is `"ready"`; every other status (or `testSelectionEnabled: false`) runs all tests for that attempt.
+- If the first response is `status: "notReady"`, the listener polls the same endpoint until it turns terminal (`ready` or another definitive status) or a timeout budget is reached:
+  - `SL_TIA_POLLING_INTERVAL_SEC` — seconds between retries (default `5`).
+  - `SL_TIA_POLLING_TIMEOUT_SEC` — total polling budget in seconds (default `60`).
+  - Setting either variable to `0` disables polling and performs a single fetch instead. Invalid values (non-numeric, negative, `inf`, `nan`) fall back to the default and log a warning.
+- Once a terminal answer (`ready` or a definitive "run all" status) is received, it is cached for the rest of the run — later suites reuse it without re-querying the backend. A non-terminal outcome (e.g. a polling timeout, or a transient failure) is retried with a single fetch on the next suite.
+- Test names returned from a `ready` response are marked as `SKIP` before execution.
 - If a skipped test has a teardown, it is removed to avoid side effects.
-- Console logs include counts and decisions for transparency.
+- Console logs include the endpoint decision (`enabled`/`status`/count), retry attempts, and timeout warnings for transparency.
 
 ### Selenium instrumentation
 - If `selenium` is installed, the listener applies:
@@ -113,5 +118,4 @@ robot --listener "/path/to/repo/robot/SLListener.py:${SL_TOKEN}::CI Tests:${LAB_
 ### File location
 - Listener source: `robot/SLListener.py`
 - This guide: `robot/SLListener.md`
-
 

--- a/robot-custom-integration/sl_python_robot/SLListener.py
+++ b/robot-custom-integration/sl_python_robot/SLListener.py
@@ -1,7 +1,9 @@
 import functools
+import math
 import os
 import socket
 import sys
+import time
 import uuid
 
 os.environ["OTEL_METRICS_EXPORTER"] = "none"
@@ -27,7 +29,7 @@ except ImportError:
     PlaywrightBrowserContext = None
 
 # Bump this string on every change to the listener.
-__version__ = "1.3.0"
+__version__ = "1.4.0"
 
 SL_TEST_LISTENER_TRACER = "sl-test-listener"
 tracer = trace.get_tracer(SL_TEST_LISTENER_TRACER)
@@ -88,6 +90,8 @@ class SLListener:
         self.bsid = bsid
         self.stage_name = stagename
         self.excluded_tests = set()
+        self.tia_resolved = False
+        self.tia_attempted = False
         self.test_session_id = None
         self.labid = labid
         self.test_project_id = testprojectid
@@ -155,20 +159,30 @@ class SLListener:
         else:
             _sl_log(f"Reusing existing session: {self.test_session_id}", level="DEBUG")
 
-        self.excluded_tests = set(self.get_excluded_tests())
+        if not self.tia_resolved:
+            names, terminal = self.get_excluded_tests(poll=not self.tia_attempted)
+            self.tia_attempted = True
+            if terminal:
+                self.excluded_tests = set(names)
+                self.tia_resolved = True
         self.mark_tests_to_be_skipped(suite)
 
     def end_suite(self, data, result):
         if not self.test_session_id:
             return
-        _sl_log(f"end_suite: '{result.longname}' | closing session {self.test_session_id}")
+        _sl_log(
+            f"end_suite: '{result.longname}' | closing session {self.test_session_id}"
+        )
         test_results = self.build_test_results(result)
         self.send_test_results(test_results)
         self.end_test_session()
 
     def start_test(self, data, result):
         test_name = self.get_encoded_test_name(data.name)
-        _sl_log(f"→ start_test: '{data.name}' | session: {self.test_session_id}", level="DEBUG")
+        _sl_log(
+            f"→ start_test: '{data.name}' | session: {self.test_session_id}",
+            level="DEBUG",
+        )
         self.try_instrument_selenium(test_name, self.test_session_id)
         self.try_instrument_playwright(test_name, self.test_session_id)
         self.start_span(test_name)
@@ -211,20 +225,113 @@ class SLListener:
             self.test_session_id = res["data"]["testSessionId"]
             _sl_log(f"Test session opened, testSessionId: {self.test_session_id}")
 
-    def get_excluded_tests(self):
-        excluded_tests = []
-        recommendations = requests.get(
-            f"{self.get_session_url()}/exclude-tests",
-            headers=self.get_header(),
-            timeout=30,
-        )
-        _sl_log(
-            f"Retrieving Recommendations: {'OK' if recommendations.ok else f'Error {recommendations.status_code}'}"
-        )
-        if recommendations.status_code == 200:
-            excluded_tests = recommendations.json()["data"]
-        _sl_log(f"{len(excluded_tests)} Skipped tests: {excluded_tests}")
-        return excluded_tests
+    def get_exclude_tests_url(self):
+        return f"{self.base_url}/v2/test-sessions/{self.test_session_id}/exclude-tests"
+
+    def _fetch_exclusions_once(self):
+        """Single GET against the v2 exclude-tests endpoint.
+
+        Returns (names, terminal, retryable). `retryable` is True only for a
+        200 response with status "notReady" — every other failure (transport
+        error, non-200, unparsable/non-dict body) is terminal-with-no-names
+        and non-retryable so the poll loop can break immediately (fail-open).
+        """
+        try:
+            response = requests.get(
+                self.get_exclude_tests_url(),
+                headers=self.get_header(),
+                timeout=30,
+            )
+        except requests.RequestException as e:
+            _sl_log(f"TIA: request failed — {e}", level="WARNING")
+            return [], False, False
+
+        if response.status_code != 200:
+            _sl_log(f"TIA: unexpected status {response.status_code}", level="WARNING")
+            return [], False, False
+
+        try:
+            body = response.json()
+        except ValueError as e:
+            _sl_log(f"TIA: failed to parse response — {e}", level="WARNING")
+            return [], False, False
+
+        if not isinstance(body, dict):
+            _sl_log("TIA: response body is not an object", level="WARNING")
+            return [], False, False
+
+        payload = body["data"] if "data" in body else body
+        metadata = payload.get("metadata") or {}
+        enabled = metadata.get("testSelectionEnabled")
+        status = metadata.get("status")
+
+        if enabled is True and status == "ready":
+            names = [
+                t["testName"]
+                for t in (payload.get("excludedTests") or [])
+                if isinstance(t, dict) and t.get("testName")
+            ]
+            _sl_log(f"TIA: enabled={enabled} status={status} → {len(names)} excluded")
+            return names, True, False
+
+        if enabled is True and status == "notReady":
+            _sl_log(f"TIA: enabled={enabled} status={status} → 0 excluded")
+            return [], False, True
+
+        _sl_log(f"TIA: enabled={enabled} status={status} → 0 excluded")
+        return [], True, False
+
+    def get_excluded_tests(self, poll=True):
+        if not self.test_session_id:
+            return [], False
+
+        timeout = self._read_positive_env("SL_TIA_POLLING_TIMEOUT_SEC", 60)
+        interval = self._read_positive_env("SL_TIA_POLLING_INTERVAL_SEC", 5)
+
+        if not poll or timeout == 0 or interval == 0:
+            names, terminal, _retryable = self._fetch_exclusions_once()
+            return names, terminal
+
+        deadline = time.monotonic() + timeout
+        names, terminal, retryable = self._fetch_exclusions_once()
+        retry_count = 0
+        while retryable and not terminal and time.monotonic() < deadline:
+            sleep_for = max(0, min(interval, deadline - time.monotonic()))
+            if sleep_for == 0:
+                break
+            retry_count += 1
+            _sl_log(
+                f"TIA notReady — retry {retry_count} in {sleep_for}s", level="DEBUG"
+            )
+            time.sleep(sleep_for)
+            names, terminal, retryable = self._fetch_exclusions_once()
+
+        if retryable and not terminal:
+            _sl_log(
+                "TIA: polling deadline reached while still notReady", level="WARNING"
+            )
+
+        return names, terminal
+
+    def _read_positive_env(self, name, default):
+        raw = os.environ.get(name)
+        if raw is None:
+            return default
+        try:
+            value = float(raw)
+        except (TypeError, ValueError):
+            _sl_log(
+                f"Invalid value for {name}={raw!r}; using default {default}",
+                level="WARNING",
+            )
+            return default
+        if not math.isfinite(value) or value < 0:
+            _sl_log(
+                f"Invalid value for {name}={raw!r}; using default {default}",
+                level="WARNING",
+            )
+            return default
+        return value
 
     def resolve_bsid_from_labid(self):
         """

--- a/robot-custom-integration/sl_python_robot/tests/test_sl_listener_component.py
+++ b/robot-custom-integration/sl_python_robot/tests/test_sl_listener_component.py
@@ -9,10 +9,13 @@ and asserts on the actual HTTP traffic.
 import json
 import threading
 from http.server import HTTPServer, BaseHTTPRequestHandler
+from types import SimpleNamespace
+from unittest.mock import MagicMock
 from urllib.parse import parse_qs, urlparse
 
 import jwt as pyjwt
 import pytest
+import requests
 
 
 # ---------------------------------------------------------------------------
@@ -23,6 +26,9 @@ class _RecordingHandler(BaseHTTPRequestHandler):
     """Records all incoming requests and returns canned SeaLights responses."""
 
     requests_log: list = []
+    # exclude-tests v2 lookup: respond notReady this many times before ready.
+    exclude_tests_not_ready_remaining: int = 0
+    exclude_tests_names: list = []
 
     def do_POST(self):
         length = int(self.headers.get("Content-Length", 0))
@@ -44,9 +50,37 @@ class _RecordingHandler(BaseHTTPRequestHandler):
         if "build-sessions/active" in self.path:
             self._respond(200, {"buildSessionId": "bsid-resolved-component"})
         elif "exclude-tests" in self.path:
-            self._respond(200, {"data": []})
+            if self.__class__.exclude_tests_not_ready_remaining > 0:
+                self.__class__.exclude_tests_not_ready_remaining -= 1
+                self._respond(
+                    200,
+                    {
+                        "data": {
+                            "metadata": {
+                                "testSelectionEnabled": True,
+                                "status": "notReady",
+                            },
+                            "excludedTests": [],
+                        }
+                    },
+                )
+            else:
+                self._respond(
+                    200,
+                    {
+                        "data": {
+                            "metadata": {
+                                "testSelectionEnabled": True,
+                                "status": "ready",
+                            },
+                            "excludedTests": self.__class__.exclude_tests_names,
+                        }
+                    },
+                )
         else:
-            self._respond(200, {})
+            # Loud failure — an unrouted GET must never masquerade as "no
+            # exclusions" (200 {}), which would mask a future routing typo.
+            self._respond(404, {"error": f"unrouted path: {self.path}"})
 
     def do_DELETE(self):
         self._record("DELETE")
@@ -84,6 +118,8 @@ class _RecordingHandler(BaseHTTPRequestHandler):
 def mock_server():
     """Start a mock HTTP server on a random port; tear down after test."""
     _RecordingHandler.requests_log = []
+    _RecordingHandler.exclude_tests_not_ready_remaining = 0
+    _RecordingHandler.exclude_tests_names = []
     server = HTTPServer(("127.0.0.1", 0), _RecordingHandler)
     port = server.server_address[1]
     thread = threading.Thread(target=server.serve_forever, daemon=True)
@@ -212,3 +248,71 @@ class TestResolveBsidQueryParam:
         resolve_calls = [r for r in logs if "build-sessions/active" in r["path"]]
         assert len(resolve_calls) == 1
         assert "testProjectId" not in resolve_calls[0]["query"]
+
+
+# ---------------------------------------------------------------------------
+# get_excluded_tests() over real HTTP — v2 exclude-tests endpoint
+# ---------------------------------------------------------------------------
+
+def _fake_robot_test(name):
+    return SimpleNamespace(name=name, body=MagicMock(), has_teardown=lambda: False)
+
+
+class TestExcludeTestsV2:
+    def test_ready_marks_matching_test_skip_and_leaves_others(self, mock_server):
+        """AC13: a ready v2 response SKIP-marks the matching test only, and
+        the recorded request path hits the v2 exclude-tests endpoint."""
+        server, port = mock_server
+        _RecordingHandler.exclude_tests_names = [{"testName": "Match Test"}]
+        listener = _make_listener(port, bsid="bsid-1")
+        listener.create_test_session()
+
+        names, terminal = listener.get_excluded_tests()
+
+        assert (names, terminal) == (["Match Test"], True)
+
+        listener.excluded_tests = set(names)
+        match_test = _fake_robot_test("Match Test")
+        other_test = _fake_robot_test("Other Test")
+        suite = SimpleNamespace(tests=[match_test, other_test])
+        listener.mark_tests_to_be_skipped(suite)
+
+        match_test.body.create_keyword.assert_called_once_with(name="SKIP")
+        other_test.body.create_keyword.assert_not_called()
+
+        logs = _get_logged_requests(mock_server)
+        exclude_calls = [
+            r for r in logs if r["method"] == "GET" and "exclude-tests" in r["path"]
+        ]
+        assert len(exclude_calls) == 1
+        assert "/v2/test-sessions/" in exclude_calls[0]["path"]
+        assert exclude_calls[0]["path"].endswith("/exclude-tests")
+
+    def test_not_ready_then_ready_over_real_http(self, mock_server, monkeypatch):
+        """The poll loop retries a real notReady response and recovers to ready."""
+        server, port = mock_server
+        monkeypatch.setenv("SL_TIA_POLLING_TIMEOUT_SEC", "5")
+        monkeypatch.setenv("SL_TIA_POLLING_INTERVAL_SEC", "0.05")
+        _RecordingHandler.exclude_tests_not_ready_remaining = 2
+        _RecordingHandler.exclude_tests_names = [{"testName": "Recovered Test"}]
+        listener = _make_listener(port, bsid="bsid-1")
+        listener.create_test_session()
+
+        names, terminal = listener.get_excluded_tests()
+
+        assert (names, terminal) == (["Recovered Test"], True)
+        logs = _get_logged_requests(mock_server)
+        exclude_calls = [
+            r for r in logs if r["method"] == "GET" and "exclude-tests" in r["path"]
+        ]
+        assert len(exclude_calls) == 3
+
+    def test_unrouted_get_path_fails_loudly(self, mock_server):
+        """AC13b: an unrouted GET must not silently look like 'no exclusions'."""
+        server, port = mock_server
+
+        response = requests.get(
+            f"http://127.0.0.1:{port}/totally/unrouted/path", timeout=5
+        )
+
+        assert response.status_code == 404

--- a/robot-custom-integration/sl_python_robot/tests/test_sl_listener_unit.py
+++ b/robot-custom-integration/sl_python_robot/tests/test_sl_listener_unit.py
@@ -12,6 +12,8 @@ import re
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import requests
+
 import _sl_listener
 
 SLListener = _sl_listener.SLListener
@@ -164,6 +166,314 @@ class TestResolveBsidFromLabid:
 
 
 # ---------------------------------------------------------------------------
+# get_excluded_tests() / _fetch_exclusions_once() — v2 exclude-tests lookup
+# ---------------------------------------------------------------------------
+
+class _FakeClock:
+    """Controllable monotonic clock: time.sleep() advances it, no real delay."""
+
+    def __init__(self, start=0.0):
+        self.now = start
+
+    def monotonic(self):
+        return self.now
+
+    def sleep(self, seconds):
+        self.now += seconds
+
+
+def _v2_body(enabled, status, excluded_tests=None):
+    return {
+        "data": {
+            "metadata": {"testSelectionEnabled": enabled, "status": status},
+            "excludedTests": excluded_tests or [],
+        }
+    }
+
+
+def _ok_response(json_body):
+    return MagicMock(status_code=200, json=lambda: json_body)
+
+
+def _status_response(status_code):
+    return MagicMock(status_code=status_code, json=lambda: {})
+
+
+class TestGetExcludedTests:
+    def _listener(self, **overrides):
+        defaults = dict(bsid="bsid-1", stagename="Robot Tests")
+        defaults.update(overrides)
+        listener = _make_listener(**defaults)
+        listener.test_session_id = "sess-1"
+        return listener
+
+    # AC1
+    @patch.object(_sl_listener, "requests")
+    def test_url_is_v2_sl_api_no_query_params(self, mock_requests):
+        mock_requests.get.return_value = _ok_response(_v2_body(True, "noHistory"))
+        listener = self._listener()
+
+        listener.get_excluded_tests(poll=False)
+
+        args, kwargs = mock_requests.get.call_args
+        url = args[0] if args else kwargs.get("url")
+        assert url == f"{listener.base_url}/v2/test-sessions/sess-1/exclude-tests"
+        assert "/sl-api" in listener.base_url
+        assert "params" not in kwargs
+        assert kwargs["headers"] == listener.get_header()
+        assert kwargs["timeout"] == 30
+
+    # AC2
+    @patch.object(_sl_listener, "requests")
+    def test_ready_names_feed_mark_tests_to_be_skipped(self, mock_requests):
+        mock_requests.get.return_value = _ok_response(
+            _v2_body(True, "ready", [{"testName": "Match Test"}])
+        )
+        listener = self._listener()
+
+        names, terminal = listener.get_excluded_tests(poll=False)
+        assert names == ["Match Test"]
+        assert terminal is True
+
+        listener.excluded_tests = set(names)
+        match_test = SimpleNamespace(
+            name="Match Test", body=MagicMock(), has_teardown=lambda: False
+        )
+        other_test = SimpleNamespace(
+            name="Other Test", body=MagicMock(), has_teardown=lambda: False
+        )
+        suite = SimpleNamespace(tests=[match_test, other_test])
+
+        listener.mark_tests_to_be_skipped(suite)
+
+        match_test.body.create_keyword.assert_called_once_with(name="SKIP")
+        other_test.body.create_keyword.assert_not_called()
+
+    # AC3
+    @patch.object(_sl_listener, "requests")
+    def test_ready_with_empty_excluded_tests(self, mock_requests):
+        mock_requests.get.return_value = _ok_response(_v2_body(True, "ready", []))
+        listener = self._listener()
+
+        names, terminal = listener.get_excluded_tests(poll=False)
+
+        assert (names, terminal) == ([], True)
+
+    # AC6
+    @patch.object(_sl_listener, "requests")
+    def test_terminal_statuses_ignore_excluded_tests_fetch_once(self, mock_requests):
+        cases = [
+            (True, "noHistory"),
+            (True, "wontBeReady"),
+            (True, "error"),
+            (False, "ready"),
+        ]
+        for enabled, status in cases:
+            mock_requests.get.reset_mock()
+            mock_requests.get.return_value = _ok_response(
+                _v2_body(enabled, status, [{"testName": "Should Not Apply"}])
+            )
+            listener = self._listener()
+
+            names, terminal = listener.get_excluded_tests()
+
+            assert (names, terminal) == ([], True), (enabled, status)
+            assert mock_requests.get.call_count == 1, (enabled, status)
+
+    # AC12
+    @patch.object(_sl_listener, "requests")
+    def test_no_envelope_body_still_parses(self, mock_requests):
+        inner_payload = _v2_body(True, "ready", [{"testName": "Bare"}])["data"]
+        mock_requests.get.return_value = _ok_response(inner_payload)
+        listener = self._listener()
+
+        names, terminal = listener.get_excluded_tests(poll=False)
+
+        assert (names, terminal) == (["Bare"], True)
+
+    # AC7 — break immediately on any non-retryable failure
+    @patch.object(_sl_listener, "requests")
+    def test_break_immediately_on_non_retryable_failures(self, mock_requests):
+        mock_requests.RequestException = requests.RequestException
+
+        for status_code in (404, 401, 500):
+            mock_requests.get.reset_mock()
+            mock_requests.get.side_effect = None
+            mock_requests.get.return_value = _status_response(status_code)
+            listener = self._listener()
+
+            names, terminal = listener.get_excluded_tests()
+
+            assert (names, terminal) == ([], False), status_code
+            assert mock_requests.get.call_count == 1, status_code
+
+        mock_requests.get.reset_mock()
+        mock_requests.get.return_value = None
+        mock_requests.get.side_effect = requests.RequestException("boom")
+        listener = self._listener()
+
+        names, terminal = listener.get_excluded_tests()
+
+        assert (names, terminal) == ([], False)
+        assert mock_requests.get.call_count == 1
+        mock_requests.get.side_effect = None
+
+        for body in ([], "x", None):
+            mock_requests.get.reset_mock()
+            mock_requests.get.return_value = MagicMock(
+                status_code=200, json=lambda body=body: body
+            )
+            listener = self._listener()
+
+            names, terminal = listener.get_excluded_tests()
+
+            assert (names, terminal) == ([], False), body
+            assert mock_requests.get.call_count == 1, body
+
+        mock_requests.get.reset_mock()
+        mock_requests.get.return_value = MagicMock(
+            status_code=200, json=MagicMock(side_effect=ValueError("bad json"))
+        )
+        listener = self._listener()
+
+        names, terminal = listener.get_excluded_tests()
+
+        assert (names, terminal) == ([], False)
+        assert mock_requests.get.call_count == 1
+
+    # AC8
+    @patch.object(_sl_listener, "requests")
+    def test_missing_session_returns_no_call(self, mock_requests):
+        listener = _make_listener(bsid="bsid-1", stagename="Robot Tests")
+        listener.test_session_id = None
+
+        names, terminal = listener.get_excluded_tests()
+
+        assert (names, terminal) == ([], False)
+        mock_requests.get.assert_not_called()
+
+    # AC4 — persistent notReady stops at the deadline (fake clock, no real sleep)
+    @patch.object(_sl_listener, "requests")
+    def test_persistent_not_ready_stops_at_deadline(self, mock_requests, monkeypatch):
+        monkeypatch.setenv("SL_TIA_POLLING_TIMEOUT_SEC", "10")
+        monkeypatch.setenv("SL_TIA_POLLING_INTERVAL_SEC", "3")
+        mock_requests.get.return_value = _ok_response(_v2_body(True, "notReady"))
+        clock = _FakeClock()
+        listener = self._listener()
+
+        with patch.object(
+            _sl_listener.time, "monotonic", side_effect=clock.monotonic
+        ), patch.object(_sl_listener.time, "sleep", side_effect=clock.sleep):
+            names, terminal = listener.get_excluded_tests()
+
+        assert (names, terminal) == ([], False)
+        # ceil(timeout/interval) loop iterations + the initial fetch
+        assert mock_requests.get.call_count == 5
+
+    # AC4b — a fetch that lands past the deadline never yields a negative sleep
+    @patch.object(_sl_listener, "requests")
+    def test_over_budget_fetch_clamps_sleep_to_zero(self, mock_requests, monkeypatch):
+        monkeypatch.setenv("SL_TIA_POLLING_TIMEOUT_SEC", "10")
+        monkeypatch.setenv("SL_TIA_POLLING_INTERVAL_SEC", "5")
+        mock_requests.get.return_value = _ok_response(_v2_body(True, "notReady"))
+
+        # 1) deadline calc -> 0 (deadline=10); 2) while-check -> 9 (< 10, enter);
+        # 3) sleep_for calc -> 11 (already past deadline) -> clamps to 0 -> break.
+        monotonic_values = iter([0, 9, 11])
+        listener = self._listener()
+
+        with patch.object(
+            _sl_listener.time,
+            "monotonic",
+            side_effect=lambda: next(monotonic_values),
+        ), patch.object(_sl_listener.time, "sleep") as mock_sleep:
+            names, terminal = listener.get_excluded_tests()
+
+        assert (names, terminal) == ([], False)
+        mock_sleep.assert_not_called()
+        for call in mock_sleep.call_args_list:
+            assert call.args[0] >= 0
+
+    # AC5
+    @patch.object(_sl_listener, "requests")
+    def test_not_ready_then_ready_returns_exclusions(self, mock_requests, monkeypatch):
+        monkeypatch.setenv("SL_TIA_POLLING_TIMEOUT_SEC", "10")
+        monkeypatch.setenv("SL_TIA_POLLING_INTERVAL_SEC", "1")
+        mock_requests.get.side_effect = [
+            _ok_response(_v2_body(True, "notReady")),
+            _ok_response(_v2_body(True, "ready", [{"testName": "T1"}])),
+        ]
+        clock = _FakeClock()
+        listener = self._listener()
+
+        with patch.object(
+            _sl_listener.time, "monotonic", side_effect=clock.monotonic
+        ), patch.object(_sl_listener.time, "sleep", side_effect=clock.sleep):
+            names, terminal = listener.get_excluded_tests()
+
+        assert (names, terminal) == (["T1"], True)
+        assert mock_requests.get.call_count == 2
+
+    # AC9b — 0 disables polling via OR, tested independently for each var
+    @patch.object(_sl_listener, "requests")
+    def test_timeout_zero_disables_polling(self, mock_requests, monkeypatch):
+        monkeypatch.setenv("SL_TIA_POLLING_TIMEOUT_SEC", "0")
+        monkeypatch.setenv("SL_TIA_POLLING_INTERVAL_SEC", "5")
+        mock_requests.get.return_value = _ok_response(_v2_body(True, "notReady"))
+        listener = self._listener()
+
+        with patch.object(_sl_listener.time, "sleep") as mock_sleep:
+            listener.get_excluded_tests()
+
+        assert mock_requests.get.call_count == 1
+        mock_sleep.assert_not_called()
+
+    @patch.object(_sl_listener, "requests")
+    def test_interval_zero_disables_polling(self, mock_requests, monkeypatch):
+        monkeypatch.setenv("SL_TIA_POLLING_TIMEOUT_SEC", "5")
+        monkeypatch.setenv("SL_TIA_POLLING_INTERVAL_SEC", "0")
+        mock_requests.get.return_value = _ok_response(_v2_body(True, "notReady"))
+        listener = self._listener()
+
+        with patch.object(_sl_listener.time, "sleep") as mock_sleep:
+            listener.get_excluded_tests()
+
+        assert mock_requests.get.call_count == 1
+        mock_sleep.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _read_positive_env() — env-var validation (AC9)
+# ---------------------------------------------------------------------------
+
+class TestReadPositiveEnv:
+    def test_defaults_when_unset(self, monkeypatch):
+        monkeypatch.delenv("SL_TEST_VAR", raising=False)
+        listener = _make_listener()
+
+        assert listener._read_positive_env("SL_TEST_VAR", 42) == 42
+
+    def test_invalid_values_fall_back_to_default(self, monkeypatch, capsys):
+        listener = _make_listener()
+        for raw in ("abc", "-1", "inf", "nan"):
+            monkeypatch.setenv("SL_TEST_VAR", raw)
+            assert listener._read_positive_env("SL_TEST_VAR", 7) == 7, raw
+        assert "[WARNING]" in capsys.readouterr().out
+
+    def test_accepts_valid_positive_float_string(self, monkeypatch):
+        listener = _make_listener()
+        monkeypatch.setenv("SL_TEST_VAR", "12.5")
+
+        assert listener._read_positive_env("SL_TEST_VAR", 1) == 12.5
+
+    def test_accepts_zero(self, monkeypatch):
+        listener = _make_listener()
+        monkeypatch.setenv("SL_TEST_VAR", "0")
+
+        assert listener._read_positive_env("SL_TEST_VAR", 1) == 0
+
+
+# ---------------------------------------------------------------------------
 # Playwright instrumentation — playwright_goto()
 # ---------------------------------------------------------------------------
 
@@ -288,6 +598,11 @@ def test_version_defined():
     assert re.match(r"^\d+\.\d+\.\d+$", _sl_listener.__version__)
 
 
+def test_version_bumped_for_v2_exclude_tests():
+    """AC14: __version__ was bumped alongside the v2 exclude-tests lookup."""
+    assert _sl_listener.__version__ == "1.4.0"
+
+
 # ---------------------------------------------------------------------------
 # _sl_log() — log level filtering
 # ---------------------------------------------------------------------------
@@ -330,7 +645,7 @@ class TestStartSuiteResolveBsidGuard:
 
         with patch.object(listener, "resolve_bsid_from_labid") as mock_resolve, \
              patch.object(listener, "create_test_session"), \
-             patch.object(listener, "get_excluded_tests", return_value=[]), \
+             patch.object(listener, "get_excluded_tests", return_value=([], False)), \
              patch.object(listener, "mark_tests_to_be_skipped"):
             listener.start_suite(suite, MagicMock())
 
@@ -347,7 +662,7 @@ class TestStartSuiteResolveBsidGuard:
 
         with patch.object(listener, "resolve_bsid_from_labid") as mock_resolve, \
              patch.object(listener, "create_test_session"), \
-             patch.object(listener, "get_excluded_tests", return_value=[]), \
+             patch.object(listener, "get_excluded_tests", return_value=([], False)), \
              patch.object(listener, "mark_tests_to_be_skipped"):
             listener.start_suite(suite, MagicMock())
 
@@ -366,12 +681,12 @@ class TestStartSuiteMultiSuiteTia:
         suite.source = "/path/to/suite.robot"
         return suite
 
-    def test_tia_filtering_runs_on_every_suite(self):
+    def test_mark_tests_to_be_skipped_runs_on_every_suite(self):
         """mark_tests_to_be_skipped must be called for every suite, not just the first."""
         listener = _make_listener(bsid="bsid-1")
 
         with patch.object(listener, "create_test_session") as mock_create, \
-             patch.object(listener, "get_excluded_tests", return_value=[]) as mock_get, \
+             patch.object(listener, "get_excluded_tests", return_value=([], True)) as mock_get, \
              patch.object(listener, "mark_tests_to_be_skipped") as mock_mark:
 
             # First suite — creates the session
@@ -382,8 +697,61 @@ class TestStartSuiteMultiSuiteTia:
             listener.start_suite(self._make_suite(), MagicMock())
 
         assert mock_create.call_count == 1
-        assert mock_get.call_count == 2
         assert mock_mark.call_count == 2
+
+    def test_terminal_ready_memoized_across_suites(self):
+        """AC10: a terminal outcome on suite 1 is memoized; later suites reuse
+        it without re-querying, but mark_tests_to_be_skipped still runs every
+        suite (asserted numerically, not "per suite")."""
+        listener = _make_listener(bsid="bsid-1")
+
+        with patch.object(listener, "create_test_session") as mock_create, \
+             patch.object(
+                 listener, "get_excluded_tests", return_value=(["T1"], True)
+             ) as mock_get, \
+             patch.object(listener, "mark_tests_to_be_skipped") as mock_mark:
+
+            listener.start_suite(self._make_suite(), MagicMock())
+            listener.test_session_id = "sess-1"
+            listener.start_suite(self._make_suite(), MagicMock())
+            listener.start_suite(self._make_suite(), MagicMock())
+
+        assert mock_create.call_count == 1
+        assert mock_get.call_count == 1
+        assert mock_mark.call_count == 3
+        assert listener.tia_resolved is True
+        assert listener.excluded_tests == {"T1"}
+
+    def test_non_terminal_suite_recovers_on_later_suite(self):
+        """AC11: a non-terminal outcome on suite 1 is not memoized; a later
+        suite that resolves ready applies exclusions; later retries are
+        single-shot (poll=False), not another full poll budget."""
+        listener = _make_listener(bsid="bsid-1")
+
+        with patch.object(listener, "create_test_session"), \
+             patch.object(
+                 listener,
+                 "get_excluded_tests",
+                 side_effect=[([], False), ([], False), (["T2"], True)],
+             ) as mock_get, \
+             patch.object(listener, "mark_tests_to_be_skipped") as mock_mark:
+
+            listener.start_suite(self._make_suite(), MagicMock())
+            assert listener.tia_resolved is False
+            listener.test_session_id = "sess-1"
+
+            listener.start_suite(self._make_suite(), MagicMock())
+            assert listener.tia_resolved is False
+
+            listener.start_suite(self._make_suite(), MagicMock())
+
+        assert mock_get.call_count == 3
+        assert mock_get.call_args_list[0].kwargs["poll"] is True
+        assert mock_get.call_args_list[1].kwargs["poll"] is False
+        assert mock_get.call_args_list[2].kwargs["poll"] is False
+        assert listener.tia_resolved is True
+        assert listener.excluded_tests == {"T2"}
+        assert mock_mark.call_count == 3
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
feat(robot-custom-integration): update SLListener to v1.4.0 with v2 exclude-tests support

- Update robot-custom-integration version to 1.4.0.
- Update behave-robot-playwright-browser example

[SLDEV-28240] fix(robot): move TIA lookup to v2 exclude-tests

[SLDEV-28240]: https://sealights.atlassian.net/browse/SLDEV-28240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ