### PR TITLE
[SLDEV-28058] feat(robot-custom-integration): add Browser Library support to SLListener

### DIFF
--- a/behave-robot-playwright-browser/robot-test-runner/SLListener.py
+++ b/behave-robot-playwright-browser/robot-test-runner/SLListener.py
@@ -1,4 +1,5 @@
 import functools
+import json
 import math
 import os
 import socket
@@ -15,6 +16,7 @@ import datetime
 import requests
 import jwt
 from opentelemetry import trace, context, baggage
+from robot.libraries.BuiltIn import BuiltIn
 
 try:
     from selenium.webdriver.remote.webdriver import WebDriver
@@ -29,13 +31,30 @@ except ImportError:
     PlaywrightBrowserContext = None
 
 # Bump this string on every change to the listener.
-__version__ = "1.4.0"
+__version__ = "1.5.0"
 
 SL_TEST_LISTENER_TRACER = "sl-test-listener"
 tracer = trace.get_tracer(SL_TEST_LISTENER_TRACER)
 
 SEALIGHTS_LOG_TAG = "[SeaLights]"
 TEST_STATUS_MAP = {"FAIL": "failed", "SKIP": "skipped"}
+
+# Shared set:context baggage keys (used by both the Selenium/Playwright and
+# Browser Library script builders so the two paths cannot silently drift).
+BAGGAGE_KEY_TEST_NAME = "x-sl-test-name"
+BAGGAGE_KEY_TEST_SESSION_ID = "x-sl-test-session-id"
+
+# Browser Library flush script — evaluate_javascript requires an arrow-wrapped function.
+BROWSER_LIBRARY_FLUSH_SCRIPT = "() => { window.$SealightsAgent.sendAllFootprints(); }"
+
+# start_keyword close/teardown detection (matched as a case-insensitive substring
+# so a library prefix like "Browser.Close Page" still matches).
+BROWSER_LIBRARY_CLOSE_KEYWORD_PATTERNS = (
+    "close page",
+    "close context",
+    "close browser",
+    "close all browsers",
+)
 
 # ── Log level control ─────────────────────────────────────────────────────────
 # Control verbosity without changing the robot command line.
@@ -100,6 +119,17 @@ class SLListener:
         self.enabled = True
         self.disabled_reason = ""
 
+        # Browser Library (robotframework-browser) state — seeded here (never
+        # first-assigned in start_test) so start_keyword/end_keyword are safe
+        # no-ops even when fired during Suite Setup, before the first start_test.
+        self.browser_lib = None
+        self.bl_page_snapshot = {}
+        self.bl_test_baggage = None
+        # Library imports are suite-scoped in Robot Framework, so detection is
+        # cached per suite (reset in start_suite) rather than re-attempted —
+        # and re-raising/swallowing an exception — on every single test.
+        self._bl_checked = False
+
         # Validate that at least one of bsid or labId is provided
         if not self.bsid and not self.labid:
             self.enabled = False
@@ -135,6 +165,7 @@ class SLListener:
             _sl_log(f"DISABLED: {self.disabled_reason}", level="WARNING")
 
     def start_suite(self, suite, result):
+        self._bl_checked = False
         if not suite.tests:
             _sl_log(
                 f"start_suite: '{suite.longname}' — no direct tests, skipping",
@@ -185,11 +216,36 @@ class SLListener:
         )
         self.try_instrument_selenium(test_name, self.test_session_id)
         self.try_instrument_playwright(test_name, self.test_session_id)
+        self.try_instrument_browser_library(test_name, self.test_session_id)
         self.start_span(test_name)
+
+    def start_keyword(self, data, result):
+        """Flush before close — end_keyword fires too late for an
+        already-closed page. See SLListener.md § Browser Library instrumentation.
+        """
+        if self.browser_lib is None:
+            return
+        keyword_name = (getattr(data, "name", "") or "").lower()
+        if not any(
+            pattern in keyword_name
+            for pattern in BROWSER_LIBRARY_CLOSE_KEYWORD_PATTERNS
+        ):
+            return
+        _sl_log(
+            f"Browser Library: close-pattern flush before '{data.name}'", level="DEBUG"
+        )
+        catalog = self._get_browser_catalog()
+        page_ids = list(_flatten_browser_catalog(catalog).keys())
+        self._run_on_browser_library_pages(
+            page_ids,
+            BROWSER_LIBRARY_FLUSH_SCRIPT,
+            _find_active_browser_page_id(catalog),
+        )
 
     def end_test(self, data, result):
         test_name = self.get_encoded_test_name(data.name)
         _sl_log(f"← end_test:   '{data.name}' | {result.status}", level="DEBUG")
+        self._flush_browser_library()
         test_span = self.spans.get(test_name)
         if test_span:
             context.detach(test_span["token"])
@@ -197,6 +253,53 @@ class SLListener:
             self.spans.pop(test_name)
         else:
             _sl_log(f"Test span not found for '{data.name}'", level="WARNING")
+
+    def _flush_browser_library(self):
+        """end_test catch-all: flush every page still open, then clear per-test state."""
+        if self.browser_lib is None:
+            return
+        catalog = self._get_browser_catalog()
+        page_ids = list(_flatten_browser_catalog(catalog).keys())
+        _sl_log(f"Browser Library: end_test flush count={len(page_ids)}", level="DEBUG")
+        self._run_on_browser_library_pages(
+            page_ids,
+            BROWSER_LIBRARY_FLUSH_SCRIPT,
+            _find_active_browser_page_id(catalog),
+        )
+        self.bl_page_snapshot = {}
+        self.bl_test_baggage = None
+
+    def end_keyword(self, data, result):
+        """Re-injects context on new/navigated Browser pages; gated on the
+        owning library (RF 7.4.2: lives on `result`, not `data`). See
+        SLListener.md § Browser Library instrumentation.
+        """
+        if self.browser_lib is None:
+            return
+        if self.bl_test_baggage is None:
+            # No live test (e.g. a Browser keyword in Suite Teardown, after
+            # end_test already cleared state) — nothing to attribute footprints to.
+            return
+        owner = getattr(result, "owner", None) or getattr(result, "libname", None)
+        if owner is not None and owner != "Browser":
+            return
+
+        catalog = self._get_browser_catalog()
+        current_snapshot = _flatten_browser_catalog(catalog)
+        changed_page_ids = _diff_browser_catalog_pages(
+            self.bl_page_snapshot, current_snapshot
+        )
+        if changed_page_ids:
+            test_name, test_session_id = self.bl_test_baggage or (None, None)
+            script = _build_browser_library_context_script(test_name, test_session_id)
+            _sl_log(
+                f"Browser Library: navigation re-inject for {changed_page_ids}",
+                level="DEBUG",
+            )
+            self._run_on_browser_library_pages(
+                changed_page_ids, script, _find_active_browser_page_id(catalog)
+            )
+        self.bl_page_snapshot = current_snapshot
 
     # --- Sealights API helpers ---
 
@@ -334,13 +437,9 @@ class SLListener:
         return value
 
     def resolve_bsid_from_labid(self):
-        """
-        Call /api/v1/lab-ids/{labId}/build-sessions/active to resolve active bsid.
-        Required query params: agentId, testStage.
-        Handling:
-          - 200: set self.bsid from response.buildSessionId
-          - 404: disable listener (no active bsid)
-          - 500: exit with error
+        """Resolves bsid via GET /v1/lab-ids/{labId}/build-sessions/active.
+        See SLListener.md § How endpoints are determined / Failure and
+        disable behavior.
         """
         api_endpoint = self.extract_sl_endpoint(replace_api_with_sl_api=False)
         url = f"{api_endpoint}/v1/lab-ids/{self.labid}/build-sessions/active"
@@ -473,6 +572,21 @@ class SLListener:
             WebDriver.quit = selenium_close_quit(WebDriver.quit)
         _dispatch_context_to_active_drivers(test_name, test_session_id)
 
+    def try_detect_browser_library(self):
+        """Never raises to Robot — get_library_instance() raises when the
+        library isn't imported, the common case for Selenium/Playwright-only
+        suites. Cached per suite; see the _bl_checked reset in start_suite.
+        """
+        if self._bl_checked:
+            return self.browser_lib
+        self._bl_checked = True
+        try:
+            instance = BuiltIn().get_library_instance("Browser")
+        except Exception:
+            instance = None
+        self.browser_lib = instance or None
+        return self.browser_lib
+
     def try_instrument_playwright(self, test_name, test_session_id):
         if PlaywrightPage:
             PlaywrightPage.goto = playwright_goto(test_name, test_session_id)(
@@ -484,6 +598,65 @@ class SLListener:
                 PlaywrightBrowserContext.close
             )
         _dispatch_context_to_active_pages(test_name, test_session_id)
+
+    def try_instrument_browser_library(self, test_name, test_session_id):
+        """Injects set:context on pre-existing pages (Suite Setup case).
+        See SLListener.md § Browser Library instrumentation.
+        """
+        self.try_detect_browser_library()
+        if self.browser_lib is None:
+            return
+        self.bl_test_baggage = (test_name, test_session_id)
+        catalog = self._get_browser_catalog()
+        self.bl_page_snapshot = _flatten_browser_catalog(catalog)
+        script = _build_browser_library_context_script(test_name, test_session_id)
+        self._run_on_browser_library_pages(
+            list(self.bl_page_snapshot.keys()),
+            script,
+            _find_active_browser_page_id(catalog),
+        )
+
+    def _get_browser_catalog(self):
+        """Read the Browser Library catalog, swallowing errors (never disables the listener)."""
+        try:
+            return self.browser_lib.get_browser_catalog()
+        except Exception as e:
+            _sl_log(f"Browser Library: get_browser_catalog failed: {e}", level="DEBUG")
+            return []
+
+    def _run_on_browser_library_pages(self, page_ids, script, active_page_id):
+        """Runs `script` on each page, restoring the originally-active page
+        (only if we actually switched away from it) even if a per-page call
+        fails mid-loop. See SLListener.md § Browser Library instrumentation
+        ("Multi-page handling").
+        """
+        if not page_ids:
+            return
+        switched = False
+        try:
+            for page_id in page_ids:
+                try:
+                    if page_id != active_page_id:
+                        self.browser_lib.switch_page(page_id)
+                        switched = True
+                    self.browser_lib.evaluate_javascript(None, script)
+                    _sl_log(
+                        f"Browser Library: ran script on page {page_id}", level="DEBUG"
+                    )
+                except Exception as e:
+                    _sl_log(
+                        f"Browser Library: script failed for page {page_id}: {e}",
+                        level="DEBUG",
+                    )
+        finally:
+            if active_page_id is not None and switched:
+                try:
+                    self.browser_lib.switch_page(active_page_id)
+                except Exception as e:
+                    _sl_log(
+                        f"Browser Library: failed to restore active page {active_page_id}: {e}",
+                        level="WARNING",
+                    )
 
     # --- Generic helpers ---
 
@@ -516,20 +689,93 @@ class SLListener:
         return quote(test_name, safe="")
 
 
+def _json_str(value):
+    """json.dumps a value as a string, stringifying non-str input first so the
+    output matches the legacy %s-formatting behavior (e.g. None -> "None")
+    while still escaping JS-unsafe characters like embedded quotes.
+    """
+    return json.dumps(str(value))
+
+
 def _build_set_context_script(test_name, test_session_id):
     return (
         'window.dispatchEvent(new CustomEvent("set:context", '
-        '{detail: {baggage: {"x-sl-test-name": "%s", "x-sl-test-session-id": "%s"}}}));'
-        % (test_name, test_session_id)
+        "{detail: {baggage: {%s: %s, %s: %s}}}));"
+        % (
+            json.dumps(BAGGAGE_KEY_TEST_NAME),
+            _json_str(test_name),
+            json.dumps(BAGGAGE_KEY_TEST_SESSION_ID),
+            _json_str(test_session_id),
+        )
     )
 
 
-def _dispatch_context_to_active_drivers(test_name, test_session_id):
-    """Dispatch set:context on any already-open browser.
+def _build_browser_library_context_script(test_name, test_session_id):
+    """Arrow-wrapped: evaluate_javascript rejects bare statement strings.
+    See SLListener.md § Browser Library instrumentation.
+    """
+    return (
+        '() => { window.dispatchEvent(new CustomEvent("set:context", '
+        "{detail: {persist: false, baggage: {%s: %s, %s: %s}}})); }"
+        % (
+            json.dumps(BAGGAGE_KEY_TEST_NAME),
+            _json_str(test_name),
+            json.dumps(BAGGAGE_KEY_TEST_SESSION_ID),
+            _json_str(test_session_id),
+        )
+    )
 
-    This handles the common case where the browser was opened in Suite Setup
-    (before start_test patches WebDriver.get), so the patched get() never fires.
-    Uses the _active_webdrivers set populated by the module-level tracking wrapper.
+
+def _flatten_browser_catalog(catalog):
+    """Flatten a Browser Library get_browser_catalog() structure into {page_id: url}.
+
+    Expected shape: [{"contexts": [{"pages": [{"id": ..., "url": ...}, ...]}, ...]}, ...]
+    """
+    pages = {}
+    for browser in catalog or []:
+        for ctx in browser.get("contexts") or []:
+            for page in ctx.get("pages") or []:
+                page_id = page.get("id")
+                if page_id is not None:
+                    pages[page_id] = page.get("url")
+    return pages
+
+
+def _find_active_browser_page_id(catalog):
+    """Return the globally active page id from a Browser Library catalog, or None.
+
+    Every browser/context in the catalog carries its own last-active
+    "activePage" (per get_browser_catalog()), even ones that aren't
+    currently focused — so the true active page is only the one under the
+    browser flagged "activeBrowser" and that browser's "activeContext",
+    mirroring Browser Library's own _get_active_triplet() lookup.
+    """
+    for browser in catalog or []:
+        if not browser.get("activeBrowser"):
+            continue
+        active_context_id = browser.get("activeContext")
+        for ctx in browser.get("contexts") or []:
+            if ctx.get("id") == active_context_id:
+                return ctx.get("activePage")
+    return None
+
+
+def _diff_browser_catalog_pages(previous_snapshot, current_snapshot):
+    """Return page ids in current_snapshot that are new or whose URL changed.
+
+    Handles nullable URLs: None->url and url->None are changes; None->None is not.
+    Pages removed from current_snapshot (already closed) are not reported.
+    """
+    return [
+        page_id
+        for page_id, url in current_snapshot.items()
+        if page_id not in previous_snapshot or previous_snapshot[page_id] != url
+    ]
+
+
+def _dispatch_context_to_active_drivers(test_name, test_session_id):
+    """Covers browsers opened in Suite Setup, before start_test patches
+    WebDriver.get. See SLListener.md § Selenium instrumentation.
     """
     if not _active_webdrivers:
         return
@@ -542,10 +788,7 @@ def _dispatch_context_to_active_drivers(test_name, test_session_id):
 
 
 def _dispatch_context_to_active_pages(test_name, test_session_id):
-    """Dispatch set:context on any already-open Playwright page.
-
-    Mirrors _dispatch_context_to_active_drivers for Playwright.
-    """
+    """Playwright counterpart to _dispatch_context_to_active_drivers."""
     if not _active_playwright_pages:
         return
     script = _build_set_context_script(test_name, test_session_id)

--- a/robot-custom-integration/sl_python_robot/SLListener.md
+++ b/robot-custom-integration/sl_python_robot/SLListener.md
@@ -8,6 +8,7 @@ The `SLListener.py` provides a Robot Framework listener that integrates your Rob
 - **Tracing**: Starts an OpenTelemetry span per test and sets baggage with test/session identifiers.
 - **Selenium instrumentation**: Monkey-patches `WebDriver.get/close/quit` to communicate with the SeaLights Browser Agent when present.
 - **Playwright instrumentation**: Monkey-patches `Page.goto/close` and `BrowserContext.close` to communicate with the SeaLights Browser Agent when present.
+- **Browser Library instrumentation**: Detects `robotframework-browser` at runtime and injects/flushes via `evaluate_javascript`, since it drives Playwright from a separate Node.js process (no in-process objects to monkey-patch).
 - **Results reporting**: Uploads aggregated test results (name, status, start/end) to SeaLights.
 
 ### Requirements
@@ -84,6 +85,7 @@ robot --listener "/path/to/repo/robot/SLListener.py:${SL_TOKEN}::CI Tests:${LAB_
 - If `selenium` is installed, the listener applies:
   - After `WebDriver.get`: injects a `CustomEvent("set:context")` with baggage containing `x-sl-test-name` and `x-sl-test-session-id`.
   - On `close`/`quit`: attempts `await window.$SealightsAgent.sendAllFootprints()`.
+  - Also dispatches `set:context` immediately to any already-open `WebDriver` at `start_test` (covers browsers opened in Suite Setup, before the patched `get` ever fires).
 - Ensure your application pages include the SeaLights Browser Agent so `window.$SealightsAgent` is available to collect web footprints.
 
 ### Playwright instrumentation
@@ -91,8 +93,21 @@ robot --listener "/path/to/repo/robot/SLListener.py:${SL_TOKEN}::CI Tests:${LAB_
   - After `Page.goto`: injects the same `CustomEvent("set:context")` with baggage containing `x-sl-test-name` and `x-sl-test-session-id`.
   - On `Page.close`: calls `window.$SealightsAgent.sendAllFootprints()` to flush browser footprints before closing.
   - On `BrowserContext.close`: flushes footprints from all open pages in the context before closing.
+  - Also dispatches `set:context` immediately to any already-open Playwright page at `start_test` (covers pages opened in Suite Setup, before the patched `goto` ever fires).
 - The same JavaScript events are dispatched as with Selenium — the SeaLights Browser Agent must be present on the application pages.
-- This works with direct Playwright Python API usage (e.g. custom Robot keyword libraries that use `playwright.sync_api`). The `robotframework-browser` (Browser Library) uses a Node.js gRPC bridge and may require a different integration approach.
+- This works with direct Playwright Python API usage (e.g. custom Robot keyword libraries that use `playwright.sync_api`).
+
+### Browser Library instrumentation (`robotframework-browser`)
+`robotframework-browser` runs Playwright in a separate Node.js process behind a gRPC bridge, so the listener's in-process Selenium/Playwright monkey-patches never fire for it. Instead the listener:
+- **Detects** the library at runtime via `BuiltIn().get_library_instance("Browser")` — no `robotframework-browser` import or dependency is required; suites that don't use it are unaffected.
+- **Injects on `start_test`**: snapshots the open-page catalog (`get_browser_catalog()`) and dispatches `set:context` on every page already open (covers browsers opened in Suite Setup).
+- **Re-injects on navigation**: after each keyword owned by the `Browser` library, diffs the catalog's `(page id, URL)` snapshot and re-injects `set:context` on new pages and on URL changes — required because injection uses `persist: false` (no `sessionStorage` auto-restore on a fresh document). Non-Browser keywords are skipped without reading the catalog; if the owning library can't be determined at all, the keyword is inspected anyway rather than skipped.
+- **Flushes before close**: when a keyword name matches a close/teardown pattern (`Close Page`, `Close Context`, `Close Browser`, `Close All Browsers`), flushes `sendAllFootprints()` on every open catalog page before the close executes — `end_keyword` fires too late to reach an already-closed page, and the specific target page isn't resolved from the keyword name, so all open pages are flushed instead (safe since flush is idempotent and close keywords are infrequent).
+- **Flushes at `end_test`**: a name-independent catch-all that flushes every page still open, regardless of how it was closed.
+- **Multi-page handling**: enumerates all pages in the catalog, uses `switch_page` to target non-active pages, and always restores the originally-active page afterward (even if a page's `switch_page`/`evaluate_javascript` call fails) — switching is invisible to the running test.
+- Uses an arrow-wrapped script (`() => { ... }`) since `evaluate_javascript` rejects bare statement strings, unlike Selenium's `execute_script`/Playwright's `page.evaluate`.
+- **Known limitation:** app-driven navigation (e.g. a meta-refresh or scripted redirect) that occurs with no intervening Browser keyword may not get `set:context` re-injected until the next Browser keyword fires; footprints in that narrow window may be untagged. Keyword-driven navigation (`Go To`, `New Page`, a `Click` that navigates) is unaffected.
+- **Prerequisite:** the same as Selenium/Playwright — your application pages must load the SeaLights Browser Agent (`window.$SealightsAgent`).
 
 ### Logging and environment
 - Console log lines are prefixed with `[SeaLights]` for easy filtering.
@@ -114,8 +129,11 @@ robot --listener "/path/to/repo/robot/SLListener.py:${SL_TOKEN}::CI Tests:${LAB_
 - "No active build session for labId" → Ensure the Lab has an active build session for the given stage.
 - Selenium JS errors → Ensure your app pages load the SeaLights Browser Agent (`window.$SealightsAgent`).
 - Playwright JS errors → Same as Selenium: ensure your app pages load the SeaLights Browser Agent (`window.$SealightsAgent`).
+- Browser Library not detected → Ensure the suite imports `Browser` before the listener's `start_test` runs; detection failures are logged at DEBUG and the listener falls back to no-op for that path.
+- Browser Library JS errors / missing footprints → Same as Selenium/Playwright: ensure your app pages load `window.$SealightsAgent`; run with `SL_LOG_LEVEL=DEBUG` to trace per-page inject/flush.
 
 ### File location
 - Listener source: `robot/SLListener.py`
 - This guide: `robot/SLListener.md`
+
 

--- a/robot-custom-integration/sl_python_robot/SLListener.py
+++ b/robot-custom-integration/sl_python_robot/SLListener.py
@@ -1,4 +1,5 @@
 import functools
+import json
 import math
 import os
 import socket
@@ -15,6 +16,7 @@ import datetime
 import requests
 import jwt
 from opentelemetry import trace, context, baggage
+from robot.libraries.BuiltIn import BuiltIn
 
 try:
     from selenium.webdriver.remote.webdriver import WebDriver
@@ -29,13 +31,30 @@ except ImportError:
     PlaywrightBrowserContext = None
 
 # Bump this string on every change to the listener.
-__version__ = "1.4.0"
+__version__ = "1.5.0"
 
 SL_TEST_LISTENER_TRACER = "sl-test-listener"
 tracer = trace.get_tracer(SL_TEST_LISTENER_TRACER)
 
 SEALIGHTS_LOG_TAG = "[SeaLights]"
 TEST_STATUS_MAP = {"FAIL": "failed", "SKIP": "skipped"}
+
+# Shared set:context baggage keys (used by both the Selenium/Playwright and
+# Browser Library script builders so the two paths cannot silently drift).
+BAGGAGE_KEY_TEST_NAME = "x-sl-test-name"
+BAGGAGE_KEY_TEST_SESSION_ID = "x-sl-test-session-id"
+
+# Browser Library flush script — evaluate_javascript requires an arrow-wrapped function.
+BROWSER_LIBRARY_FLUSH_SCRIPT = "() => { window.$SealightsAgent.sendAllFootprints(); }"
+
+# start_keyword close/teardown detection (matched as a case-insensitive substring
+# so a library prefix like "Browser.Close Page" still matches).
+BROWSER_LIBRARY_CLOSE_KEYWORD_PATTERNS = (
+    "close page",
+    "close context",
+    "close browser",
+    "close all browsers",
+)
 
 # ── Log level control ─────────────────────────────────────────────────────────
 # Control verbosity without changing the robot command line.
@@ -100,6 +119,17 @@ class SLListener:
         self.enabled = True
         self.disabled_reason = ""
 
+        # Browser Library (robotframework-browser) state — seeded here (never
+        # first-assigned in start_test) so start_keyword/end_keyword are safe
+        # no-ops even when fired during Suite Setup, before the first start_test.
+        self.browser_lib = None
+        self.bl_page_snapshot = {}
+        self.bl_test_baggage = None
+        # Library imports are suite-scoped in Robot Framework, so detection is
+        # cached per suite (reset in start_suite) rather than re-attempted —
+        # and re-raising/swallowing an exception — on every single test.
+        self._bl_checked = False
+
         # Validate that at least one of bsid or labId is provided
         if not self.bsid and not self.labid:
             self.enabled = False
@@ -135,6 +165,7 @@ class SLListener:
             _sl_log(f"DISABLED: {self.disabled_reason}", level="WARNING")
 
     def start_suite(self, suite, result):
+        self._bl_checked = False
         if not suite.tests:
             _sl_log(
                 f"start_suite: '{suite.longname}' — no direct tests, skipping",
@@ -185,11 +216,36 @@ class SLListener:
         )
         self.try_instrument_selenium(test_name, self.test_session_id)
         self.try_instrument_playwright(test_name, self.test_session_id)
+        self.try_instrument_browser_library(test_name, self.test_session_id)
         self.start_span(test_name)
+
+    def start_keyword(self, data, result):
+        """Flush before close — end_keyword fires too late for an
+        already-closed page. See SLListener.md § Browser Library instrumentation.
+        """
+        if self.browser_lib is None:
+            return
+        keyword_name = (getattr(data, "name", "") or "").lower()
+        if not any(
+            pattern in keyword_name
+            for pattern in BROWSER_LIBRARY_CLOSE_KEYWORD_PATTERNS
+        ):
+            return
+        _sl_log(
+            f"Browser Library: close-pattern flush before '{data.name}'", level="DEBUG"
+        )
+        catalog = self._get_browser_catalog()
+        page_ids = list(_flatten_browser_catalog(catalog).keys())
+        self._run_on_browser_library_pages(
+            page_ids,
+            BROWSER_LIBRARY_FLUSH_SCRIPT,
+            _find_active_browser_page_id(catalog),
+        )
 
     def end_test(self, data, result):
         test_name = self.get_encoded_test_name(data.name)
         _sl_log(f"← end_test:   '{data.name}' | {result.status}", level="DEBUG")
+        self._flush_browser_library()
         test_span = self.spans.get(test_name)
         if test_span:
             context.detach(test_span["token"])
@@ -197,6 +253,53 @@ class SLListener:
             self.spans.pop(test_name)
         else:
             _sl_log(f"Test span not found for '{data.name}'", level="WARNING")
+
+    def _flush_browser_library(self):
+        """end_test catch-all: flush every page still open, then clear per-test state."""
+        if self.browser_lib is None:
+            return
+        catalog = self._get_browser_catalog()
+        page_ids = list(_flatten_browser_catalog(catalog).keys())
+        _sl_log(f"Browser Library: end_test flush count={len(page_ids)}", level="DEBUG")
+        self._run_on_browser_library_pages(
+            page_ids,
+            BROWSER_LIBRARY_FLUSH_SCRIPT,
+            _find_active_browser_page_id(catalog),
+        )
+        self.bl_page_snapshot = {}
+        self.bl_test_baggage = None
+
+    def end_keyword(self, data, result):
+        """Re-injects context on new/navigated Browser pages; gated on the
+        owning library (RF 7.4.2: lives on `result`, not `data`). See
+        SLListener.md § Browser Library instrumentation.
+        """
+        if self.browser_lib is None:
+            return
+        if self.bl_test_baggage is None:
+            # No live test (e.g. a Browser keyword in Suite Teardown, after
+            # end_test already cleared state) — nothing to attribute footprints to.
+            return
+        owner = getattr(result, "owner", None) or getattr(result, "libname", None)
+        if owner is not None and owner != "Browser":
+            return
+
+        catalog = self._get_browser_catalog()
+        current_snapshot = _flatten_browser_catalog(catalog)
+        changed_page_ids = _diff_browser_catalog_pages(
+            self.bl_page_snapshot, current_snapshot
+        )
+        if changed_page_ids:
+            test_name, test_session_id = self.bl_test_baggage or (None, None)
+            script = _build_browser_library_context_script(test_name, test_session_id)
+            _sl_log(
+                f"Browser Library: navigation re-inject for {changed_page_ids}",
+                level="DEBUG",
+            )
+            self._run_on_browser_library_pages(
+                changed_page_ids, script, _find_active_browser_page_id(catalog)
+            )
+        self.bl_page_snapshot = current_snapshot
 
     # --- Sealights API helpers ---
 
@@ -334,13 +437,9 @@ class SLListener:
         return value
 
     def resolve_bsid_from_labid(self):
-        """
-        Call /api/v1/lab-ids/{labId}/build-sessions/active to resolve active bsid.
-        Required query params: agentId, testStage.
-        Handling:
-          - 200: set self.bsid from response.buildSessionId
-          - 404: disable listener (no active bsid)
-          - 500: exit with error
+        """Resolves bsid via GET /v1/lab-ids/{labId}/build-sessions/active.
+        See SLListener.md § How endpoints are determined / Failure and
+        disable behavior.
         """
         api_endpoint = self.extract_sl_endpoint(replace_api_with_sl_api=False)
         url = f"{api_endpoint}/v1/lab-ids/{self.labid}/build-sessions/active"
@@ -473,6 +572,21 @@ class SLListener:
             WebDriver.quit = selenium_close_quit(WebDriver.quit)
         _dispatch_context_to_active_drivers(test_name, test_session_id)
 
+    def try_detect_browser_library(self):
+        """Never raises to Robot — get_library_instance() raises when the
+        library isn't imported, the common case for Selenium/Playwright-only
+        suites. Cached per suite; see the _bl_checked reset in start_suite.
+        """
+        if self._bl_checked:
+            return self.browser_lib
+        self._bl_checked = True
+        try:
+            instance = BuiltIn().get_library_instance("Browser")
+        except Exception:
+            instance = None
+        self.browser_lib = instance or None
+        return self.browser_lib
+
     def try_instrument_playwright(self, test_name, test_session_id):
         if PlaywrightPage:
             PlaywrightPage.goto = playwright_goto(test_name, test_session_id)(
@@ -484,6 +598,65 @@ class SLListener:
                 PlaywrightBrowserContext.close
             )
         _dispatch_context_to_active_pages(test_name, test_session_id)
+
+    def try_instrument_browser_library(self, test_name, test_session_id):
+        """Injects set:context on pre-existing pages (Suite Setup case).
+        See SLListener.md § Browser Library instrumentation.
+        """
+        self.try_detect_browser_library()
+        if self.browser_lib is None:
+            return
+        self.bl_test_baggage = (test_name, test_session_id)
+        catalog = self._get_browser_catalog()
+        self.bl_page_snapshot = _flatten_browser_catalog(catalog)
+        script = _build_browser_library_context_script(test_name, test_session_id)
+        self._run_on_browser_library_pages(
+            list(self.bl_page_snapshot.keys()),
+            script,
+            _find_active_browser_page_id(catalog),
+        )
+
+    def _get_browser_catalog(self):
+        """Read the Browser Library catalog, swallowing errors (never disables the listener)."""
+        try:
+            return self.browser_lib.get_browser_catalog()
+        except Exception as e:
+            _sl_log(f"Browser Library: get_browser_catalog failed: {e}", level="DEBUG")
+            return []
+
+    def _run_on_browser_library_pages(self, page_ids, script, active_page_id):
+        """Runs `script` on each page, restoring the originally-active page
+        (only if we actually switched away from it) even if a per-page call
+        fails mid-loop. See SLListener.md § Browser Library instrumentation
+        ("Multi-page handling").
+        """
+        if not page_ids:
+            return
+        switched = False
+        try:
+            for page_id in page_ids:
+                try:
+                    if page_id != active_page_id:
+                        self.browser_lib.switch_page(page_id)
+                        switched = True
+                    self.browser_lib.evaluate_javascript(None, script)
+                    _sl_log(
+                        f"Browser Library: ran script on page {page_id}", level="DEBUG"
+                    )
+                except Exception as e:
+                    _sl_log(
+                        f"Browser Library: script failed for page {page_id}: {e}",
+                        level="DEBUG",
+                    )
+        finally:
+            if active_page_id is not None and switched:
+                try:
+                    self.browser_lib.switch_page(active_page_id)
+                except Exception as e:
+                    _sl_log(
+                        f"Browser Library: failed to restore active page {active_page_id}: {e}",
+                        level="WARNING",
+                    )
 
     # --- Generic helpers ---
 
@@ -516,20 +689,93 @@ class SLListener:
         return quote(test_name, safe="")
 
 
+def _json_str(value):
+    """json.dumps a value as a string, stringifying non-str input first so the
+    output matches the legacy %s-formatting behavior (e.g. None -> "None")
+    while still escaping JS-unsafe characters like embedded quotes.
+    """
+    return json.dumps(str(value))
+
+
 def _build_set_context_script(test_name, test_session_id):
     return (
         'window.dispatchEvent(new CustomEvent("set:context", '
-        '{detail: {baggage: {"x-sl-test-name": "%s", "x-sl-test-session-id": "%s"}}}));'
-        % (test_name, test_session_id)
+        "{detail: {baggage: {%s: %s, %s: %s}}}));"
+        % (
+            json.dumps(BAGGAGE_KEY_TEST_NAME),
+            _json_str(test_name),
+            json.dumps(BAGGAGE_KEY_TEST_SESSION_ID),
+            _json_str(test_session_id),
+        )
     )
 
 
-def _dispatch_context_to_active_drivers(test_name, test_session_id):
-    """Dispatch set:context on any already-open browser.
+def _build_browser_library_context_script(test_name, test_session_id):
+    """Arrow-wrapped: evaluate_javascript rejects bare statement strings.
+    See SLListener.md § Browser Library instrumentation.
+    """
+    return (
+        '() => { window.dispatchEvent(new CustomEvent("set:context", '
+        "{detail: {persist: false, baggage: {%s: %s, %s: %s}}})); }"
+        % (
+            json.dumps(BAGGAGE_KEY_TEST_NAME),
+            _json_str(test_name),
+            json.dumps(BAGGAGE_KEY_TEST_SESSION_ID),
+            _json_str(test_session_id),
+        )
+    )
 
-    This handles the common case where the browser was opened in Suite Setup
-    (before start_test patches WebDriver.get), so the patched get() never fires.
-    Uses the _active_webdrivers set populated by the module-level tracking wrapper.
+
+def _flatten_browser_catalog(catalog):
+    """Flatten a Browser Library get_browser_catalog() structure into {page_id: url}.
+
+    Expected shape: [{"contexts": [{"pages": [{"id": ..., "url": ...}, ...]}, ...]}, ...]
+    """
+    pages = {}
+    for browser in catalog or []:
+        for ctx in browser.get("contexts") or []:
+            for page in ctx.get("pages") or []:
+                page_id = page.get("id")
+                if page_id is not None:
+                    pages[page_id] = page.get("url")
+    return pages
+
+
+def _find_active_browser_page_id(catalog):
+    """Return the globally active page id from a Browser Library catalog, or None.
+
+    Every browser/context in the catalog carries its own last-active
+    "activePage" (per get_browser_catalog()), even ones that aren't
+    currently focused — so the true active page is only the one under the
+    browser flagged "activeBrowser" and that browser's "activeContext",
+    mirroring Browser Library's own _get_active_triplet() lookup.
+    """
+    for browser in catalog or []:
+        if not browser.get("activeBrowser"):
+            continue
+        active_context_id = browser.get("activeContext")
+        for ctx in browser.get("contexts") or []:
+            if ctx.get("id") == active_context_id:
+                return ctx.get("activePage")
+    return None
+
+
+def _diff_browser_catalog_pages(previous_snapshot, current_snapshot):
+    """Return page ids in current_snapshot that are new or whose URL changed.
+
+    Handles nullable URLs: None->url and url->None are changes; None->None is not.
+    Pages removed from current_snapshot (already closed) are not reported.
+    """
+    return [
+        page_id
+        for page_id, url in current_snapshot.items()
+        if page_id not in previous_snapshot or previous_snapshot[page_id] != url
+    ]
+
+
+def _dispatch_context_to_active_drivers(test_name, test_session_id):
+    """Covers browsers opened in Suite Setup, before start_test patches
+    WebDriver.get. See SLListener.md § Selenium instrumentation.
     """
     if not _active_webdrivers:
         return
@@ -542,10 +788,7 @@ def _dispatch_context_to_active_drivers(test_name, test_session_id):
 
 
 def _dispatch_context_to_active_pages(test_name, test_session_id):
-    """Dispatch set:context on any already-open Playwright page.
-
-    Mirrors _dispatch_context_to_active_drivers for Playwright.
-    """
+    """Playwright counterpart to _dispatch_context_to_active_drivers."""
     if not _active_playwright_pages:
         return
     script = _build_set_context_script(test_name, test_session_id)

--- a/robot-custom-integration/sl_python_robot/tests/test_sl_listener_unit.py
+++ b/robot-custom-integration/sl_python_robot/tests/test_sl_listener_unit.py
@@ -34,6 +34,7 @@ def _make_listener(**overrides):
 # __init__
 # ---------------------------------------------------------------------------
 
+
 class TestInit:
     def test_stores_test_project_id(self):
         listener = _make_listener(testprojectid="my-project")
@@ -53,6 +54,7 @@ class TestInit:
 # ---------------------------------------------------------------------------
 # get_header()
 # ---------------------------------------------------------------------------
+
 
 class TestGetHeader:
     def test_includes_testprojectid_when_set(self):
@@ -76,6 +78,7 @@ class TestGetHeader:
 # ---------------------------------------------------------------------------
 # create_test_session()
 # ---------------------------------------------------------------------------
+
 
 class TestCreateTestSession:
     @patch.object(_sl_listener, "requests")
@@ -126,6 +129,7 @@ class TestCreateTestSession:
 # ---------------------------------------------------------------------------
 # resolve_bsid_from_labid()
 # ---------------------------------------------------------------------------
+
 
 class TestResolveBsidFromLabid:
     @patch.object(_sl_listener.jwt, "decode", return_value=MOCK_JWT_PAYLOAD)
@@ -477,6 +481,7 @@ class TestReadPositiveEnv:
 # Playwright instrumentation — playwright_goto()
 # ---------------------------------------------------------------------------
 
+
 class TestPlaywrightGoto:
     def test_calls_original_and_injects_baggage(self):
         """After page.goto(), the baggage JS event should be dispatched."""
@@ -509,6 +514,7 @@ class TestPlaywrightGoto:
 # ---------------------------------------------------------------------------
 # Playwright instrumentation — playwright_close()
 # ---------------------------------------------------------------------------
+
 
 class TestPlaywrightClose:
     def test_flushes_footprints_before_close(self):
@@ -543,6 +549,7 @@ class TestPlaywrightClose:
 # ---------------------------------------------------------------------------
 # Playwright instrumentation — playwright_context_close()
 # ---------------------------------------------------------------------------
+
 
 class TestPlaywrightContextClose:
     def test_flushes_all_pages_before_close(self):
@@ -593,19 +600,21 @@ class TestPlaywrightContextClose:
 # Version constant
 # ---------------------------------------------------------------------------
 
+
 def test_version_defined():
     assert hasattr(_sl_listener, "__version__")
     assert re.match(r"^\d+\.\d+\.\d+$", _sl_listener.__version__)
 
 
-def test_version_bumped_for_v2_exclude_tests():
-    """AC14: __version__ was bumped alongside the v2 exclude-tests lookup."""
-    assert _sl_listener.__version__ == "1.4.0"
+def test_version_bumped_for_browser_library_support():
+    """__version__ was bumped alongside Browser Library support (SLDEV-28058)."""
+    assert _sl_listener.__version__ == "1.5.0"
 
 
 # ---------------------------------------------------------------------------
 # _sl_log() — log level filtering
 # ---------------------------------------------------------------------------
+
 
 class TestSlLog:
     def test_prints_at_threshold(self, capsys):
@@ -633,6 +642,7 @@ class TestSlLog:
 # start_suite — resolve_bsid_from_labid guard
 # ---------------------------------------------------------------------------
 
+
 class TestStartSuiteResolveBsidGuard:
     def test_skips_resolve_when_bsid_already_set(self):
         """resolve_bsid_from_labid must not be called if bsid is already known."""
@@ -643,10 +653,12 @@ class TestStartSuiteResolveBsidGuard:
         suite.longname = "Suite"
         suite.source = "/path/to/suite.robot"
 
-        with patch.object(listener, "resolve_bsid_from_labid") as mock_resolve, \
-             patch.object(listener, "create_test_session"), \
-             patch.object(listener, "get_excluded_tests", return_value=([], False)), \
-             patch.object(listener, "mark_tests_to_be_skipped"):
+        with (
+            patch.object(listener, "resolve_bsid_from_labid") as mock_resolve,
+            patch.object(listener, "create_test_session"),
+            patch.object(listener, "get_excluded_tests", return_value=([], False)),
+            patch.object(listener, "mark_tests_to_be_skipped"),
+        ):
             listener.start_suite(suite, MagicMock())
 
         mock_resolve.assert_not_called()
@@ -660,10 +672,12 @@ class TestStartSuiteResolveBsidGuard:
         suite.longname = "Suite"
         suite.source = "/path/to/suite.robot"
 
-        with patch.object(listener, "resolve_bsid_from_labid") as mock_resolve, \
-             patch.object(listener, "create_test_session"), \
-             patch.object(listener, "get_excluded_tests", return_value=([], False)), \
-             patch.object(listener, "mark_tests_to_be_skipped"):
+        with (
+            patch.object(listener, "resolve_bsid_from_labid") as mock_resolve,
+            patch.object(listener, "create_test_session"),
+            patch.object(listener, "get_excluded_tests", return_value=([], False)),
+            patch.object(listener, "mark_tests_to_be_skipped"),
+        ):
             listener.start_suite(suite, MagicMock())
 
         mock_resolve.assert_called_once()
@@ -672,6 +686,7 @@ class TestStartSuiteResolveBsidGuard:
 # ---------------------------------------------------------------------------
 # start_suite — TIA filtering runs on every suite, not just the first
 # ---------------------------------------------------------------------------
+
 
 class TestStartSuiteMultiSuiteTia:
     def _make_suite(self):
@@ -685,10 +700,11 @@ class TestStartSuiteMultiSuiteTia:
         """mark_tests_to_be_skipped must be called for every suite, not just the first."""
         listener = _make_listener(bsid="bsid-1")
 
-        with patch.object(listener, "create_test_session") as mock_create, \
-             patch.object(listener, "get_excluded_tests", return_value=([], True)) as mock_get, \
-             patch.object(listener, "mark_tests_to_be_skipped") as mock_mark:
-
+        with (
+            patch.object(listener, "create_test_session") as mock_create,
+            patch.object(listener, "get_excluded_tests", return_value=([], True)) as mock_get,
+            patch.object(listener, "mark_tests_to_be_skipped") as mock_mark,
+        ):
             # First suite — creates the session
             listener.start_suite(self._make_suite(), MagicMock())
             # Simulate session being set (create_test_session is mocked)
@@ -758,17 +774,22 @@ class TestStartSuiteMultiSuiteTia:
 # Playwright instrumentation — try_instrument_playwright()
 # ---------------------------------------------------------------------------
 
+
 class TestTryInstrumentPlaywright:
     def test_patches_playwright_page_when_available(self):
         """When PlaywrightPage is not None, goto and close should be patched."""
         original_goto = MagicMock()
         original_close = MagicMock()
 
-        mock_page_cls = type("MockPage", (), {"goto": original_goto, "close": original_close})
+        mock_page_cls = type(
+            "MockPage", (), {"goto": original_goto, "close": original_close}
+        )
         mock_ctx_cls = type("MockCtx", (), {"close": MagicMock()})
 
-        with patch.object(_sl_listener, "PlaywrightPage", mock_page_cls), \
-             patch.object(_sl_listener, "PlaywrightBrowserContext", mock_ctx_cls):
+        with (
+            patch.object(_sl_listener, "PlaywrightPage", mock_page_cls),
+            patch.object(_sl_listener, "PlaywrightBrowserContext", mock_ctx_cls),
+        ):
             listener = _make_listener()
             listener.try_instrument_playwright("test1", "sess-1")
 
@@ -777,8 +798,10 @@ class TestTryInstrumentPlaywright:
 
     def test_noop_when_playwright_not_installed(self):
         """When PlaywrightPage is None, no patching should occur."""
-        with patch.object(_sl_listener, "PlaywrightPage", None), \
-             patch.object(_sl_listener, "PlaywrightBrowserContext", None):
+        with (
+            patch.object(_sl_listener, "PlaywrightPage", None),
+            patch.object(_sl_listener, "PlaywrightBrowserContext", None),
+        ):
             listener = _make_listener()
             listener.try_instrument_playwright("test1", "sess-1")
 
@@ -787,18 +810,27 @@ class TestTryInstrumentPlaywright:
 # build_test_results() — per-test timestamps (SLDEV-28046)
 # ---------------------------------------------------------------------------
 
+
 class TestBuildTestResults:
     def _make_test(self, name, status, starttime, endtime):
-        return SimpleNamespace(name=name, status=status, starttime=starttime, endtime=endtime)
+        return SimpleNamespace(
+            name=name, status=status, starttime=starttime, endtime=endtime
+        )
 
     def _make_suite_result(self, tests, suite_starttime, suite_endtime):
-        return SimpleNamespace(tests=tests, starttime=suite_starttime, endtime=suite_endtime)
+        return SimpleNamespace(
+            tests=tests, starttime=suite_starttime, endtime=suite_endtime
+        )
 
     def test_uses_per_test_timestamps_not_suite(self):
         """Each result entry must carry the individual test's start/end, not the suite's."""
         listener = _make_listener()
-        t1 = self._make_test("Test A", "PASS", "20240101 00:00:01.000", "20240101 00:00:02.000")
-        t2 = self._make_test("Test B", "PASS", "20240101 00:00:03.000", "20240101 00:00:05.000")
+        t1 = self._make_test(
+            "Test A", "PASS", "20240101 00:00:01.000", "20240101 00:00:02.000"
+        )
+        t2 = self._make_test(
+            "Test B", "PASS", "20240101 00:00:03.000", "20240101 00:00:05.000"
+        )
         suite_result = self._make_suite_result(
             [t1, t2],
             suite_starttime="20240101 00:00:00.000",
@@ -823,9 +855,15 @@ class TestBuildTestResults:
     def test_different_tests_get_different_timestamps(self):
         """Two tests with different run times must produce different start/end values."""
         listener = _make_listener()
-        t1 = self._make_test("Slow Test", "PASS", "20240101 00:00:00.000", "20240101 00:00:30.000")
-        t2 = self._make_test("Fast Test", "PASS", "20240101 00:00:31.000", "20240101 00:00:32.000")
-        suite_result = self._make_suite_result([t1, t2], "20240101 00:00:00.000", "20240101 00:00:32.000")
+        t1 = self._make_test(
+            "Slow Test", "PASS", "20240101 00:00:00.000", "20240101 00:00:30.000"
+        )
+        t2 = self._make_test(
+            "Fast Test", "PASS", "20240101 00:00:31.000", "20240101 00:00:32.000"
+        )
+        suite_result = self._make_suite_result(
+            [t1, t2], "20240101 00:00:00.000", "20240101 00:00:32.000"
+        )
 
         results = listener.build_test_results(suite_result)
 
@@ -836,7 +874,9 @@ class TestBuildTestResults:
         """Tests with None starttime/endtime (e.g. skipped before execution) must not crash."""
         listener = _make_listener()
         t = self._make_test("Skipped Test", "SKIP", None, None)
-        suite_result = self._make_suite_result([t], "20240101 00:00:00.000", "20240101 00:00:01.000")
+        suite_result = self._make_suite_result(
+            [t], "20240101 00:00:00.000", "20240101 00:00:01.000"
+        )
 
         results = listener.build_test_results(suite_result)
 
@@ -846,3 +886,769 @@ class TestBuildTestResults:
             "start": 0,
             "end": 0,
         }
+
+
+# ---------------------------------------------------------------------------
+# Browser Library — __init__ state seeding (SLDEV-28058)
+# ---------------------------------------------------------------------------
+
+
+class TestBrowserLibraryInitState:
+    def test_seeds_browser_lib_state(self):
+        listener = _make_listener()
+        assert listener.browser_lib is None
+        assert listener.bl_page_snapshot == {}
+        assert listener.bl_test_baggage is None
+        assert listener._bl_checked is False
+
+
+# ---------------------------------------------------------------------------
+# Browser Library — try_detect_browser_library()
+# ---------------------------------------------------------------------------
+
+
+class TestTryDetectBrowserLibrary:
+    def test_stores_instance_on_success(self):
+        listener = _make_listener()
+        mock_browser = MagicMock()
+        with patch.object(_sl_listener, "BuiltIn") as mock_builtin_cls:
+            mock_builtin_cls.return_value.get_library_instance.return_value = (
+                mock_browser
+            )
+            result = listener.try_detect_browser_library()
+
+        assert result is mock_browser
+        assert listener.browser_lib is mock_browser
+
+    def test_returns_none_when_get_library_instance_raises(self):
+        listener = _make_listener()
+        with patch.object(_sl_listener, "BuiltIn") as mock_builtin_cls:
+            mock_builtin_cls.return_value.get_library_instance.side_effect = (
+                RuntimeError("No library 'Browser' found")
+            )
+            result = listener.try_detect_browser_library()
+
+        assert result is None
+        assert listener.browser_lib is None
+
+    def test_returns_none_when_get_library_instance_returns_falsy(self):
+        listener = _make_listener()
+        with patch.object(_sl_listener, "BuiltIn") as mock_builtin_cls:
+            mock_builtin_cls.return_value.get_library_instance.return_value = None
+            result = listener.try_detect_browser_library()
+
+        assert result is None
+        assert listener.browser_lib is None
+
+    def test_second_call_within_same_suite_is_cached(self):
+        """Detection is cached per suite — a second call must not re-invoke
+        get_library_instance, so absent-library suites don't raise once per
+        test."""
+        listener = _make_listener()
+        with patch.object(_sl_listener, "BuiltIn") as mock_builtin_cls:
+            mock_builtin_cls.return_value.get_library_instance.side_effect = (
+                RuntimeError("No library 'Browser' found")
+            )
+            first = listener.try_detect_browser_library()
+            second = listener.try_detect_browser_library()
+
+        assert first is None
+        assert second is None
+        mock_builtin_cls.return_value.get_library_instance.assert_called_once()
+
+    def test_cache_resets_on_new_suite(self):
+        """start_suite resets the cache so a later suite can detect the
+        library even if an earlier suite in the same run did not import it."""
+        listener = _make_listener(bsid="bsid-1")
+        with patch.object(_sl_listener, "BuiltIn") as mock_builtin_cls:
+            mock_builtin_cls.return_value.get_library_instance.side_effect = (
+                RuntimeError("No library 'Browser' found")
+            )
+            listener.try_detect_browser_library()
+
+        suite = MagicMock()
+        suite.tests = []
+        listener.start_suite(suite, MagicMock())
+
+        mock_browser = MagicMock()
+        with patch.object(_sl_listener, "BuiltIn") as mock_builtin_cls:
+            mock_builtin_cls.return_value.get_library_instance.return_value = (
+                mock_browser
+            )
+            result = listener.try_detect_browser_library()
+
+        assert result is mock_browser
+
+
+# ---------------------------------------------------------------------------
+# Browser Library — _build_browser_library_context_script()
+# ---------------------------------------------------------------------------
+
+
+class TestBuildBrowserLibraryContextScript:
+    def test_is_arrow_wrapped(self):
+        script = _sl_listener._build_browser_library_context_script(
+            "test%20A", "sess-1"
+        )
+        assert script.startswith("() => {")
+        assert script.rstrip().endswith("}")
+
+    def test_contains_encoded_name_and_session(self):
+        script = _sl_listener._build_browser_library_context_script(
+            "test%20A", "sess-1"
+        )
+        assert "test%20A" in script
+        assert "sess-1" in script
+
+    def test_uses_persist_false(self):
+        script = _sl_listener._build_browser_library_context_script("t1", "s1")
+        assert "persist: false" in script
+
+    def test_uses_shared_baggage_key_constants(self):
+        script = _sl_listener._build_browser_library_context_script("t1", "s1")
+        assert _sl_listener.BAGGAGE_KEY_TEST_NAME in script
+        assert _sl_listener.BAGGAGE_KEY_TEST_SESSION_ID in script
+
+    def test_separate_from_selenium_playwright_builder(self):
+        bl_script = _sl_listener._build_browser_library_context_script("t1", "s1")
+        legacy_script = _sl_listener._build_set_context_script("t1", "s1")
+        assert bl_script != legacy_script
+
+
+# ---------------------------------------------------------------------------
+# Browser Library — _build_set_context_script() byte-identical after refactor
+# ---------------------------------------------------------------------------
+
+
+class TestBuildSetContextScriptUnchanged:
+    def test_output_byte_identical_to_pre_refactor_shape(self):
+        script = _sl_listener._build_set_context_script("test%20A", "sess-1")
+        assert script == (
+            'window.dispatchEvent(new CustomEvent("set:context", '
+            '{detail: {baggage: {"x-sl-test-name": "test%20A", '
+            '"x-sl-test-session-id": "sess-1"}}}));'
+        )
+
+    def test_none_session_id_byte_identical_to_pre_refactor_shape(self):
+        """Regression: json.dumps(None) alone would emit a bare `null`
+        instead of the legacy %s-formatted string "None"."""
+        script = _sl_listener._build_set_context_script("test%20A", None)
+        assert script == (
+            'window.dispatchEvent(new CustomEvent("set:context", '
+            '{detail: {baggage: {"x-sl-test-name": "test%20A", '
+            '"x-sl-test-session-id": "None"}}}));'
+        )
+
+
+# ---------------------------------------------------------------------------
+# Browser Library — context script builders escape untrusted values
+# ---------------------------------------------------------------------------
+
+
+class TestContextScriptEscaping:
+    def test_set_context_script_escapes_quotes_in_session_id(self):
+        """A session id containing a double quote must not break out of the
+        JS string literal — json.dumps escapes it instead of interpolating raw."""
+        script = _sl_listener._build_set_context_script("t1", 'sess"1')
+        assert '\\"' in script
+        assert 'sess"1' not in script
+
+    def test_browser_library_script_escapes_quotes_in_session_id(self):
+        script = _sl_listener._build_browser_library_context_script("t1", 'sess"1')
+        assert '\\"' in script
+        assert 'sess"1' not in script
+
+    def test_browser_library_script_stringifies_none_session_id(self):
+        """None must not surface as a bare JS `null` — kept consistent with
+        the Selenium/Playwright builder's "None" string for the same input."""
+        script = _sl_listener._build_browser_library_context_script("t1", None)
+        assert '"x-sl-test-session-id": "None"' in script
+        assert "null" not in script
+
+
+# ---------------------------------------------------------------------------
+# Browser Library — _flatten_browser_catalog()
+# ---------------------------------------------------------------------------
+
+
+class TestFlattenBrowserCatalog:
+    def test_flattens_nested_browsers_contexts_pages(self):
+        catalog = [
+            {
+                "contexts": [
+                    {
+                        "pages": [
+                            {"id": "page1", "url": "https://a.com"},
+                            {"id": "page2", "url": "https://b.com"},
+                        ]
+                    }
+                ]
+            },
+            {"contexts": [{"pages": [{"id": "page3", "url": "https://c.com"}]}]},
+        ]
+
+        result = _sl_listener._flatten_browser_catalog(catalog)
+
+        assert result == {
+            "page1": "https://a.com",
+            "page2": "https://b.com",
+            "page3": "https://c.com",
+        }
+
+    def test_empty_catalog(self):
+        assert _sl_listener._flatten_browser_catalog([]) == {}
+
+    def test_none_catalog(self):
+        assert _sl_listener._flatten_browser_catalog(None) == {}
+
+    def test_context_with_no_pages(self):
+        catalog = [{"contexts": [{"pages": []}]}]
+        assert _sl_listener._flatten_browser_catalog(catalog) == {}
+
+
+# ---------------------------------------------------------------------------
+# Browser Library — _find_active_browser_page_id()
+# ---------------------------------------------------------------------------
+
+
+class TestFindActiveBrowserPageId:
+    def test_returns_active_page_id(self):
+        catalog = [
+            {
+                "activeBrowser": True,
+                "activeContext": "ctx1",
+                "contexts": [{"id": "ctx1", "activePage": "page2", "pages": []}],
+            }
+        ]
+        assert _sl_listener._find_active_browser_page_id(catalog) == "page2"
+
+    def test_returns_none_when_no_active_page(self):
+        catalog = [
+            {
+                "activeBrowser": True,
+                "activeContext": "ctx1",
+                "contexts": [{"id": "ctx1", "pages": []}],
+            }
+        ]
+        assert _sl_listener._find_active_browser_page_id(catalog) is None
+
+    def test_returns_none_for_empty_catalog(self):
+        assert _sl_listener._find_active_browser_page_id([]) is None
+
+    def test_ignores_activepage_of_non_active_browser(self):
+        """Regression: every browser/context tracks its own last-active page
+        (per get_browser_catalog()'s docstring sample), even ones that are
+        not the globally focused browser — only the browser flagged
+        activeBrowser (and its activeContext) is authoritative."""
+        catalog = [
+            {
+                "activeBrowser": False,
+                "activeContext": "ctx1",
+                "contexts": [{"id": "ctx1", "activePage": "page1", "pages": []}],
+            },
+            {
+                "activeBrowser": True,
+                "activeContext": "ctx2",
+                "contexts": [{"id": "ctx2", "activePage": "page2", "pages": []}],
+            },
+        ]
+        assert _sl_listener._find_active_browser_page_id(catalog) == "page2"
+
+    def test_ignores_activepage_of_non_active_context(self):
+        """Regression: a non-active context's activePage must not be picked
+        up even when it belongs to the globally active browser."""
+        catalog = [
+            {
+                "activeBrowser": True,
+                "activeContext": "ctx2",
+                "contexts": [
+                    {"id": "ctx1", "activePage": "page1", "pages": []},
+                    {"id": "ctx2", "activePage": "page2", "pages": []},
+                ],
+            }
+        ]
+        assert _sl_listener._find_active_browser_page_id(catalog) == "page2"
+
+
+# ---------------------------------------------------------------------------
+# Browser Library — _diff_browser_catalog_pages() (incl. I4 nullable URLs)
+# ---------------------------------------------------------------------------
+
+
+class TestDiffBrowserCatalogPages:
+    def test_new_page_is_reported(self):
+        previous = {}
+        current = {"page1": "https://a.com"}
+        assert _sl_listener._diff_browser_catalog_pages(previous, current) == ["page1"]
+
+    def test_url_change_is_reported(self):
+        previous = {"page1": "https://a.com"}
+        current = {"page1": "https://b.com"}
+        assert _sl_listener._diff_browser_catalog_pages(previous, current) == ["page1"]
+
+    def test_unchanged_page_not_reported(self):
+        previous = {"page1": "https://a.com"}
+        current = {"page1": "https://a.com"}
+        assert _sl_listener._diff_browser_catalog_pages(previous, current) == []
+
+    def test_removed_page_tolerated(self):
+        previous = {"page1": "https://a.com", "page2": "https://b.com"}
+        current = {"page1": "https://a.com"}
+        assert _sl_listener._diff_browser_catalog_pages(previous, current) == []
+
+    def test_none_to_url_is_a_change(self):
+        previous = {"page1": None}
+        current = {"page1": "https://a.com"}
+        assert _sl_listener._diff_browser_catalog_pages(previous, current) == ["page1"]
+
+    def test_url_to_none_is_a_change(self):
+        previous = {"page1": "https://a.com"}
+        current = {"page1": None}
+        assert _sl_listener._diff_browser_catalog_pages(previous, current) == ["page1"]
+
+    def test_none_to_none_is_not_a_change(self):
+        previous = {"page1": None}
+        current = {"page1": None}
+        assert _sl_listener._diff_browser_catalog_pages(previous, current) == []
+
+
+# ---------------------------------------------------------------------------
+# Browser Library — _run_on_browser_library_pages() (S2 multi-page routine)
+# ---------------------------------------------------------------------------
+
+
+class TestRunOnBrowserLibraryPages:
+    def test_switches_non_active_pages_and_restores_active_page(self):
+        listener = _make_listener()
+        mock_browser = MagicMock()
+        listener.browser_lib = mock_browser
+
+        listener._run_on_browser_library_pages(["page1", "page2"], "() => {}", "page1")
+
+        # page1 is already active: no switch needed for it, only page2
+        mock_browser.switch_page.assert_any_call("page2")
+        assert mock_browser.evaluate_javascript.call_count == 2
+        # restore call at the end targets the originally-active page
+        assert mock_browser.switch_page.call_args_list[-1].args == ("page1",)
+        # exactly one switch to page2 + one restore to page1, no redundant calls
+        assert mock_browser.switch_page.call_count == 2
+
+    def test_no_restore_when_only_active_page_processed(self):
+        """If every target page was already active (no switch happened), the
+        finally block must not issue a redundant restore switch_page call."""
+        listener = _make_listener()
+        mock_browser = MagicMock()
+        listener.browser_lib = mock_browser
+
+        listener._run_on_browser_library_pages(["page1"], "() => {}", "page1")
+
+        mock_browser.evaluate_javascript.assert_called_once()
+        mock_browser.switch_page.assert_not_called()
+
+    def test_empty_page_ids_no_crash(self):
+        listener = _make_listener()
+        mock_browser = MagicMock()
+        listener.browser_lib = mock_browser
+
+        listener._run_on_browser_library_pages([], "() => {}", None)
+
+        mock_browser.evaluate_javascript.assert_not_called()
+        mock_browser.switch_page.assert_not_called()
+
+    def test_switches_every_page_when_active_page_id_unknown(self):
+        """When the catalog has no activePage, every page must still be
+        switched to individually — otherwise evaluate_javascript would run
+        repeatedly against whatever page happens to already be current."""
+        listener = _make_listener()
+        mock_browser = MagicMock()
+        listener.browser_lib = mock_browser
+
+        listener._run_on_browser_library_pages(
+            ["page1", "page2"], "() => {}", None
+        )
+
+        mock_browser.switch_page.assert_any_call("page1")
+        mock_browser.switch_page.assert_any_call("page2")
+        assert mock_browser.evaluate_javascript.call_count == 2
+        # no active page to restore
+        assert mock_browser.switch_page.call_count == 2
+
+    def test_restores_active_page_and_processes_remaining_after_mid_loop_error(self):
+        """AC4b: a middle page's switch_page raises; remaining pages still
+        processed AND the active page is still restored (asserted together)."""
+        listener = _make_listener()
+        mock_browser = MagicMock()
+        listener.browser_lib = mock_browser
+
+        def switch_side_effect(page_id):
+            if page_id == "page2":
+                raise RuntimeError("stale page, upstream issue #1867")
+
+        mock_browser.switch_page.side_effect = switch_side_effect
+
+        listener._run_on_browser_library_pages(
+            ["page1", "page2", "page3"], "() => {}", "page1"
+        )
+
+        # page1 (active, no switch) and page3 (switch succeeded) were evaluated;
+        # page2 was skipped because its switch_page raised.
+        assert mock_browser.evaluate_javascript.call_count == 2
+        # the captured active page (page1) is still restored in the finally.
+        assert mock_browser.switch_page.call_args_list[-1].args == ("page1",)
+
+
+# ---------------------------------------------------------------------------
+# Browser Library — try_instrument_browser_library() (S2 start_test injection)
+# ---------------------------------------------------------------------------
+
+
+class TestTryInstrumentBrowserLibrary:
+    def _make_catalog(self, pages, active_page_id=None):
+        return [
+            {
+                "activeBrowser": True,
+                "activeContext": "ctx1",
+                "contexts": [
+                    {"id": "ctx1", "activePage": active_page_id, "pages": pages}
+                ],
+            }
+        ]
+
+    def test_injects_on_all_pre_existing_catalog_pages(self):
+        listener = _make_listener()
+        mock_browser = MagicMock()
+        catalog = self._make_catalog(
+            [
+                {"id": "page1", "url": "https://a.com"},
+                {"id": "page2", "url": "https://b.com"},
+            ],
+            active_page_id="page1",
+        )
+        mock_browser.get_browser_catalog.return_value = catalog
+
+        with patch.object(listener, "try_detect_browser_library") as mock_detect:
+            mock_detect.side_effect = lambda: setattr(
+                listener, "browser_lib", mock_browser
+            )
+            listener.try_instrument_browser_library("test1", "sess-1")
+
+        assert mock_browser.evaluate_javascript.call_count == 2
+        mock_browser.switch_page.assert_any_call("page2")
+        assert listener.bl_page_snapshot == {
+            "page1": "https://a.com",
+            "page2": "https://b.com",
+        }
+
+    def test_script_is_arrow_wrapped_with_correct_baggage(self):
+        listener = _make_listener()
+        mock_browser = MagicMock()
+        catalog = self._make_catalog(
+            [{"id": "page1", "url": "https://a.com"}], active_page_id="page1"
+        )
+        mock_browser.get_browser_catalog.return_value = catalog
+
+        with patch.object(listener, "try_detect_browser_library") as mock_detect:
+            mock_detect.side_effect = lambda: setattr(
+                listener, "browser_lib", mock_browser
+            )
+            listener.try_instrument_browser_library("test%20A", "sess-1")
+
+        script = mock_browser.evaluate_javascript.call_args[0][1]
+        assert script.startswith("() => {")
+        assert "test%20A" in script
+        assert "sess-1" in script
+
+    def test_empty_catalog_no_crash(self):
+        listener = _make_listener()
+        mock_browser = MagicMock()
+        mock_browser.get_browser_catalog.return_value = []
+
+        with patch.object(listener, "try_detect_browser_library") as mock_detect:
+            mock_detect.side_effect = lambda: setattr(
+                listener, "browser_lib", mock_browser
+            )
+            listener.try_instrument_browser_library("test1", "sess-1")
+
+        mock_browser.evaluate_javascript.assert_not_called()
+
+    def test_noop_when_browser_library_absent(self):
+        listener = _make_listener()
+        with patch.object(listener, "try_detect_browser_library"):
+            listener.try_instrument_browser_library("test1", "sess-1")
+
+        assert listener.bl_page_snapshot == {}
+        assert listener.bl_test_baggage is None
+
+
+# ---------------------------------------------------------------------------
+# Browser Library — end_keyword() (S3 gated catalog diff)
+# ---------------------------------------------------------------------------
+
+
+class TestEndKeyword:
+    def _make_catalog(self, pages, active_page_id=None):
+        return [
+            {
+                "activeBrowser": True,
+                "activeContext": "ctx1",
+                "contexts": [
+                    {"id": "ctx1", "activePage": active_page_id, "pages": pages}
+                ],
+            }
+        ]
+
+    def test_noop_when_browser_library_absent(self):
+        listener = _make_listener()
+        listener.end_keyword(MagicMock(), MagicMock(owner="Browser"))
+        # no crash; nothing to assert on browser_lib since it stays None
+
+    def test_non_browser_keyword_does_not_read_catalog(self):
+        """AC6b: owner != 'Browser' must never trigger get_browser_catalog()."""
+        listener = _make_listener()
+        mock_browser = MagicMock()
+        listener.browser_lib = mock_browser
+        listener.bl_test_baggage = ("test1", "sess-1")
+
+        listener.end_keyword(MagicMock(), MagicMock(owner="BuiltIn", libname="BuiltIn"))
+
+        mock_browser.get_browser_catalog.assert_not_called()
+
+    def test_noop_when_test_baggage_is_none(self):
+        """Suite Teardown gap: browser_lib stays cached after the last test's
+        end_test clears bl_test_baggage, so a Browser keyword firing in Suite
+        Teardown must not inject context with no real test identity."""
+        listener = _make_listener()
+        mock_browser = MagicMock()
+        listener.browser_lib = mock_browser
+        listener.bl_test_baggage = None
+
+        listener.end_keyword(MagicMock(), MagicMock(owner="Browser"))
+
+        mock_browser.get_browser_catalog.assert_not_called()
+
+    def test_browser_keyword_new_page_injects(self):
+        listener = _make_listener()
+        mock_browser = MagicMock()
+        listener.browser_lib = mock_browser
+        listener.bl_page_snapshot = {}
+        listener.bl_test_baggage = ("test1", "sess-1")
+        mock_browser.get_browser_catalog.return_value = self._make_catalog(
+            [{"id": "page1", "url": "https://a.com"}], active_page_id="page1"
+        )
+
+        listener.end_keyword(MagicMock(), MagicMock(owner="Browser"))
+
+        mock_browser.evaluate_javascript.assert_called_once()
+        assert listener.bl_page_snapshot == {"page1": "https://a.com"}
+
+    def test_same_page_new_url_reinjects(self):
+        """AC1b: navigation on the same page id must re-inject, not be suppressed."""
+        listener = _make_listener()
+        mock_browser = MagicMock()
+        listener.browser_lib = mock_browser
+        listener.bl_page_snapshot = {"page1": "https://a.com"}
+        listener.bl_test_baggage = ("test1", "sess-1")
+        mock_browser.get_browser_catalog.return_value = self._make_catalog(
+            [{"id": "page1", "url": "https://b.com"}], active_page_id="page1"
+        )
+
+        listener.end_keyword(MagicMock(), MagicMock(owner="Browser"))
+
+        mock_browser.evaluate_javascript.assert_called_once()
+        assert listener.bl_page_snapshot == {"page1": "https://b.com"}
+
+    def test_unchanged_page_does_not_inject(self):
+        listener = _make_listener()
+        mock_browser = MagicMock()
+        listener.browser_lib = mock_browser
+        listener.bl_page_snapshot = {"page1": "https://a.com"}
+        listener.bl_test_baggage = ("test1", "sess-1")
+        mock_browser.get_browser_catalog.return_value = self._make_catalog(
+            [{"id": "page1", "url": "https://a.com"}], active_page_id="page1"
+        )
+
+        listener.end_keyword(MagicMock(), MagicMock(owner="Browser"))
+
+        mock_browser.evaluate_javascript.assert_not_called()
+        assert listener.bl_page_snapshot == {"page1": "https://a.com"}
+
+    def test_both_owner_and_libname_none_still_inspects(self):
+        """Defensive fallback: if owner/libname are both missing, inspect anyway."""
+        listener = _make_listener()
+        mock_browser = MagicMock()
+        listener.browser_lib = mock_browser
+        listener.bl_test_baggage = ("test1", "sess-1")
+        mock_browser.get_browser_catalog.return_value = self._make_catalog(
+            [{"id": "page1", "url": "https://a.com"}], active_page_id="page1"
+        )
+
+        listener.end_keyword(MagicMock(), MagicMock(owner=None, libname=None))
+
+        mock_browser.get_browser_catalog.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Browser Library — start_keyword() close-pattern flush (S4)
+# ---------------------------------------------------------------------------
+
+
+class TestStartKeywordClosePatternFlush:
+    def _make_catalog(self, pages, active_page_id=None):
+        return [
+            {
+                "activeBrowser": True,
+                "activeContext": "ctx1",
+                "contexts": [
+                    {"id": "ctx1", "activePage": active_page_id, "pages": pages}
+                ],
+            }
+        ]
+
+    def test_noop_when_browser_library_absent(self):
+        listener = _make_listener()
+        data = SimpleNamespace(name="Close Page")
+        listener.start_keyword(data, MagicMock())
+        # no crash; browser_lib stays None so nothing else to assert
+
+    def test_close_pattern_keyword_flushes_before_close(self):
+        """AC2b: sendAllFootprints must be invoked in start_keyword before the close runs."""
+        listener = _make_listener()
+        mock_browser = MagicMock()
+        listener.browser_lib = mock_browser
+        mock_browser.get_browser_catalog.return_value = self._make_catalog(
+            [{"id": "page1", "url": "https://a.com"}], active_page_id="page1"
+        )
+        data = SimpleNamespace(name="Browser.Close Page")
+
+        listener.start_keyword(data, MagicMock())
+
+        mock_browser.evaluate_javascript.assert_called_once_with(
+            None, _sl_listener.BROWSER_LIBRARY_FLUSH_SCRIPT
+        )
+
+    def test_non_close_keyword_does_not_flush(self):
+        listener = _make_listener()
+        mock_browser = MagicMock()
+        listener.browser_lib = mock_browser
+        data = SimpleNamespace(name="Click")
+
+        listener.start_keyword(data, MagicMock())
+
+        mock_browser.get_browser_catalog.assert_not_called()
+        mock_browser.evaluate_javascript.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Browser Library — end_test() catch-all flush (S4)
+# ---------------------------------------------------------------------------
+
+
+class TestEndTestBrowserLibraryFlush:
+    def _make_catalog(self, pages, active_page_id=None):
+        return [
+            {
+                "activeBrowser": True,
+                "activeContext": "ctx1",
+                "contexts": [
+                    {"id": "ctx1", "activePage": active_page_id, "pages": pages}
+                ],
+            }
+        ]
+
+    def test_flushes_each_open_page_and_clears_state(self):
+        """AC4 flush side: genuinely multi-page — sendAllFootprints on each page."""
+        listener = _make_listener()
+        mock_browser = MagicMock()
+        listener.browser_lib = mock_browser
+        listener.bl_page_snapshot = {
+            "page1": "https://a.com",
+            "page2": "https://b.com",
+        }
+        listener.bl_test_baggage = ("test1", "sess-1")
+        mock_browser.get_browser_catalog.return_value = self._make_catalog(
+            [
+                {"id": "page1", "url": "https://a.com"},
+                {"id": "page2", "url": "https://b.com"},
+            ],
+            active_page_id="page1",
+        )
+
+        listener.end_test(
+            SimpleNamespace(name="Test 1"), SimpleNamespace(status="PASS")
+        )
+
+        assert mock_browser.evaluate_javascript.call_count == 2
+        for call in mock_browser.evaluate_javascript.call_args_list:
+            assert call.args == (None, _sl_listener.BROWSER_LIBRARY_FLUSH_SCRIPT)
+        assert listener.bl_page_snapshot == {}
+        assert listener.bl_test_baggage is None
+
+    def test_evaluate_javascript_raising_is_swallowed_and_end_test_completes(self):
+        """AC6 dedicated: a missing $SealightsAgent at flush must not crash end_test."""
+        listener = _make_listener()
+        mock_browser = MagicMock()
+        listener.browser_lib = mock_browser
+        mock_browser.evaluate_javascript.side_effect = RuntimeError(
+            "$SealightsAgent missing"
+        )
+        mock_browser.get_browser_catalog.return_value = self._make_catalog(
+            [{"id": "page1", "url": "https://a.com"}], active_page_id="page1"
+        )
+
+        listener.end_test(
+            SimpleNamespace(name="Test 1"), SimpleNamespace(status="PASS")
+        )
+
+        assert listener.bl_page_snapshot == {}
+
+    def test_span_teardown_still_runs(self):
+        """Existing span-ending logic must be preserved alongside the new flush."""
+        listener = _make_listener()
+        test_name = listener.get_encoded_test_name("Test 1")
+        listener.start_span(test_name)
+        assert test_name in listener.spans
+
+        listener.end_test(
+            SimpleNamespace(name="Test 1"), SimpleNamespace(status="PASS")
+        )
+
+        assert test_name not in listener.spans
+
+    def test_noop_when_browser_library_absent(self):
+        listener = _make_listener()
+        listener.end_test(
+            SimpleNamespace(name="Test 1"), SimpleNamespace(status="PASS")
+        )
+        # no crash
+
+
+# ---------------------------------------------------------------------------
+# Browser Library — coexistence guards + non-regression (S5)
+# ---------------------------------------------------------------------------
+
+
+class TestBrowserLibraryCoexistenceGuards:
+    def test_start_keyword_and_end_keyword_noop_when_browser_absent(self):
+        """AC5: with Browser Library absent, the new hooks make no catalog calls."""
+        listener = _make_listener()
+        assert listener.browser_lib is None
+
+        with patch.object(_sl_listener, "BuiltIn") as mock_builtin_cls:
+            mock_builtin_cls.return_value.get_library_instance.side_effect = (
+                RuntimeError("not imported")
+            )
+            listener.start_keyword(
+                SimpleNamespace(name="Close Page"), MagicMock(owner="Browser")
+            )
+            listener.end_keyword(MagicMock(), MagicMock(owner="Browser"))
+
+        assert listener.browser_lib is None
+
+    def test_hooks_before_first_start_test_do_not_raise(self):
+        """AC5b: Suite Setup keywords fire before the first start_test — must not
+        raise AttributeError against __init__-seeded state."""
+        listener = _make_listener()
+
+        listener.start_keyword(SimpleNamespace(name="Open Browser"), MagicMock())
+        listener.end_keyword(MagicMock(), MagicMock(owner="Browser"))
+        # no exception raised — hooks early-return against __init__-seeded state


### PR DESCRIPTION
## Summary

- Adds [robotframework-browser](https://github.com/MarketSquare/robotframework-browser) (Browser Library) instrumentation to the `SLListener`, alongside the existing Selenium/Playwright paths, so browser interactions get SeaLights context injection and per-test footprint flushing. Listener bumped to `1.5.0`.
- Flushes footprints on close keywords (`Close Page`/`Close Context`/`Close Browser`/`Close All Browsers`) via `start_keyword`, because `end_keyword` fires too late for an already-closed page; adds an end-of-test flush as a backstop.
- Caches Browser Library detection per suite (suite-scoped imports) and seeds all Browser Library state in `__init__` so `start_keyword`/`end_keyword` are safe no-ops when fired during Suite Setup before the first `start_test`.
- Applies the same changes to the `behave-robot-playwright-browser/robot-test-runner/SLListener.py` example, updates `SLListener.md` docs, and expands unit tests.

## Changes

- `robot-custom-integration/sl_python_robot/SLListener.py` — Browser Library instrumentation
- `robot-custom-integration/sl_python_robot/SLListener.md` — docs
- `robot-custom-integration/sl_python_robot/tests/test_sl_listener_unit.py` — expanded unit coverage
- `behave-robot-playwright-browser/robot-test-runner/SLListener.py` — mirrored listener changes

## Test plan

- [x] `pytest` unit suite for the listener passes
- [x] Manual run of a Browser Library robot suite confirms footprints flush on page/context/browser close and at end of test
- [x] Selenium/Playwright paths still behave as before (no regression)