### PR TITLE
feat(lambda-sl-layer-mirror): add SL Lambda layer mirroring script + docs

### DIFF
--- a/lambda-sl-layer-mirror/README.md
+++ b/lambda-sl-layer-mirror/README.md
@@ -1,0 +1,59 @@
+# Mirror a SeaLights Lambda Layer Into Your Own AWS Account
+
+`mirror-sl-layer.sh` copies a SeaLights-published Lambda layer into **your** AWS account and republishes it under your own layer ARN.
+
+## Why you might need this
+
+SeaLights publishes serverless agents (Python, Node, and Java) as AWS Lambda layers in a SeaLights-owned account. Many organizations can't (or won't) reference an external, third-party layer ARN directly from their functions — common reasons include:
+
+- Security policies that forbid attaching layers owned by another AWS account.
+- Air-gapped, region-restricted, or otherwise isolated environments.
+- Wanting full control over the exact artifact deployed, in their own account.
+
+This script solves that: it reads the SeaLights layer (a cross-account read that SeaLights explicitly allows), verifies its integrity, and republishes an identical copy as a layer **you own**. You then reference *your* layer ARN from your functions.
+
+## What this script does — and does not — do
+
+- **It does:** download the SeaLights layer content, verify its checksum, and publish an identical copy into your account.
+- **It does NOT** touch, create, or modify any of your Lambda functions; describe or demonstrate the SeaLights Lambda integration process.
+
+## Prerequisites
+
+- The AWS CLI, configured with **your own** account's credentials.
+- `jq`, `curl`, and `openssl` on your `PATH`.
+
+## Usage
+
+```bash
+./mirror-sl-layer.sh --tech <tech> --version <n> --region <region> [options]
+```
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `-t, --tech` | yes | One of `nodejs-cjs`, `nodejs-esm`, `python`, `java` |
+| `-v, --version` | yes | The **SeaLights** layer version you want to mirror |
+| `-r, --region` | yes | AWS region (e.g. `us-east-1`, `eu-west-1`) |
+| `-n, --target-name` | no | Layer name to publish under in your account (defaults to the SeaLights layer name) |
+| `-a, --source-account` | no | Source (SeaLights) account id (defaults to the SeaLights-owned account) |
+| `-k, --keep` | no | Keep the downloaded layer zip instead of deleting it |
+
+Example — mirror version `6` of the Node.js (CJS) layer in `us-east-1`:
+
+```bash
+./mirror-sl-layer.sh --tech nodejs-cjs --version 6 --region us-east-1
+```
+
+On success it prints the new layer ARN in your account. That is the ARN you attach to your functions.
+
+## Important: keep the source ARN in the layer description
+
+The script **automatically records the original SeaLights source ARN in the description** of the layer it publishes into your account. We strongly urge you to keep it there.
+
+Here's why it matters. AWS assigns layer version numbers **sequentially and independently per account** — the number simply counts how many times *that layer name* has been published *in that account*. It has no relationship to SeaLights' version numbering. So the version number you see in your account will almost never match the SeaLights version you actually mirrored.
+
+For example, the very first layer you publish becomes version `1` in your account — even if it's a mirror of SeaLights version `6`.
+
+That mismatch makes it impossible to tell which SeaLights layer version you're running just by looking at your own version number. The source ARN in the description is the one reliable record of exactly what you mirrored. Keeping it there means:
+
+- You can see at a glance which SeaLights layer version each of your layer versions came from.
+- If you ever open a support ticket, SeaLights can immediately identify the exact agent version you're running — which makes troubleshooting far faster.

--- a/lambda-sl-layer-mirror/README.md
+++ b/lambda-sl-layer-mirror/README.md
@@ -1,5 +1,7 @@
 # Mirror a SeaLights Lambda Layer Into Your Own AWS Account
 
+> **This is an example, not an official SeaLights product or supported tool.** `mirror-sl-layer.sh` is a reference script that demonstrates one way to use the AWS CLI to download a SeaLights-published Lambda layer and re-upload it into a customer's own AWS account (see "Why you might need this" below). It is meant to be **forked and used as a starting point** to inform your own decisions about how to manage this mirroring step — adapt it to your account structure, security policies, tooling, and automation as you see fit. If you'd like help tailoring this to your environment, or have questions about the approach, reach out to your SeaLights Solutions Architect.
+
 `mirror-sl-layer.sh` copies a SeaLights-published Lambda layer into **your** AWS account and republishes it under your own layer ARN.
 
 ## Why you might need this

--- a/lambda-sl-layer-mirror/README.md
+++ b/lambda-sl-layer-mirror/README.md
@@ -25,7 +25,7 @@ This script solves that: it reads the SeaLights layer (a cross-account read that
 ## Usage
 
 ```bash
-./mirror-sl-layer.sh --tech <tech> --version <n> --region <region> [options]
+./mirror-sl-layer.sh --tech <nodejs-cjs|nodejs-esm|python|java> --version <n> --region <region> [options]
 ```
 
 | Flag | Required | Description |
@@ -34,8 +34,8 @@ This script solves that: it reads the SeaLights layer (a cross-account read that
 | `-v, --version` | yes | The **SeaLights** layer version you want to mirror |
 | `-r, --region` | yes | AWS region (e.g. `us-east-1`, `eu-west-1`) |
 | `-n, --target-name` | no | Layer name to publish under in your account (defaults to the SeaLights layer name) |
-| `-a, --source-account` | no | Source (SeaLights) account id (defaults to the SeaLights-owned account) |
 | `-k, --keep` | no | Keep the downloaded layer zip instead of deleting it |
+| `-h, --help` | no | Show usage help and exit |
 
 Example — mirror version `6` of the Node.js (CJS) layer in `us-east-1`:
 

--- a/lambda-sl-layer-mirror/mirror-sl-layer.sh
+++ b/lambda-sl-layer-mirror/mirror-sl-layer.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+#
+# mirror-sl-layer.sh
+#
+# Mirror a published SeaLights Lambda layer from the SeaLights AWS account into
+# your own AWS account. Reads the source layer version (cross-account, no auth on
+# the download URL), verifies its integrity, and republishes it under your account
+# with the original source ARN recorded in the layer description.
+#
+# Usage:
+#   ./mirror-sl-layer.sh --tech <tech> --version <n> --region <region> [options]
+#
+# Required:
+#   -t, --tech <tech>        One of: nodejs-cjs | nodejs-esm | python | java
+#   -v, --version <n>        Source layer version number to mirror
+#   -r, --region <region>    AWS region (e.g. us-east-1, eu-west-1)
+#
+# Optional:
+#   -a, --source-account <id>  Source (SeaLights) account id (default: 442677231940)
+#   -n, --target-name <name>   Layer name to publish into your account
+#                              (default: same as the source layer name)
+#   -k, --keep                 Keep the downloaded layer.zip instead of deleting it
+#   -h, --help                 Show this help and exit
+#
+# Requirements: awscli (configured with YOUR credentials), jq, curl, openssl
+#
+set -euo pipefail
+
+# --- source layer names (the 4 published techs) ---------------------------------
+SL_LAYER_NODEJS_CJS="sl-nodejs-layer-cjs"
+SL_LAYER_NODEJS_ESM="sl-nodejs-layer-esm"
+SL_LAYER_PYTHON="sl-python-layer"
+SL_LAYER_JAVA="sl-java-layer"
+
+SOURCE_ACCOUNT="442677231940"
+
+TECH=""
+VERSION=""
+REGION=""
+TARGET_NAME=""
+KEEP_ZIP="false"
+
+usage() {
+  sed -n '2,25p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+# --- parse args -----------------------------------------------------------------
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -t|--tech)           TECH="${2:-}"; shift 2 ;;
+    -v|--version)        VERSION="${2:-}"; shift 2 ;;
+    -r|--region)         REGION="${2:-}"; shift 2 ;;
+    -a|--source-account) SOURCE_ACCOUNT="${2:-}"; shift 2 ;;
+    -n|--target-name)    TARGET_NAME="${2:-}"; shift 2 ;;
+    -k|--keep)           KEEP_ZIP="true"; shift ;;
+    -h|--help)           usage; exit 0 ;;
+    *) die "unknown argument: $1 (use --help)" ;;
+  esac
+done
+
+[[ -n "$TECH" ]]    || die "--tech is required (nodejs-cjs | nodejs-esm | python | java)"
+[[ -n "$VERSION" ]] || die "--version is required"
+[[ -n "$REGION" ]]  || die "--region is required"
+
+# --- map tech -> source layer name ----------------------------------------------
+case "$TECH" in
+  nodejs-cjs) SOURCE_LAYER="$SL_LAYER_NODEJS_CJS" ;;
+  nodejs-esm) SOURCE_LAYER="$SL_LAYER_NODEJS_ESM" ;;
+  python)     SOURCE_LAYER="$SL_LAYER_PYTHON" ;;
+  java)       SOURCE_LAYER="$SL_LAYER_JAVA" ;;
+  *) die "invalid --tech '$TECH' (nodejs-cjs | nodejs-esm | python | java)" ;;
+esac
+
+TARGET_NAME="${TARGET_NAME:-$SOURCE_LAYER}"
+
+# --- dependency check -----------------------------------------------------------
+for bin in aws jq curl openssl; do
+  command -v "$bin" >/dev/null 2>&1 || die "required tool '$bin' not found on PATH"
+done
+
+SOURCE_ARN="arn:aws:lambda:${REGION}:${SOURCE_ACCOUNT}:layer:${SOURCE_LAYER}:${VERSION}"
+
+echo "==> Mirroring SeaLights layer"
+echo "    source ARN : ${SOURCE_ARN}"
+echo "    region     : ${REGION}"
+echo "    target name: ${TARGET_NAME}"
+echo
+
+# 0. Show which account we're about to publish INTO (should be YOUR account).
+CALLER_ACCOUNT="$(aws sts get-caller-identity --query Account --output text 2>/dev/null || echo 'unknown')"
+echo "==> Publishing into account: ${CALLER_ACCOUNT}"
+if [[ "$CALLER_ACCOUNT" == "$SOURCE_ACCOUNT" ]]; then
+  die "your credentials resolve to the SeaLights source account (${SOURCE_ACCOUNT}); use your own account's credentials"
+fi
+echo
+
+# 1. Cross-account read of the source layer metadata (uses YOUR creds; allowed by
+#    Principal:* on the SeaLights layer).
+echo "==> Reading source layer metadata"
+META="$(aws lambda get-layer-version-by-arn --arn "$SOURCE_ARN" --region "$REGION")"
+URL="$(echo "$META" | jq -r '.Content.Location')"
+SHA="$(echo "$META" | jq -r '.Content.CodeSha256')"
+
+# Carry the source layer's compatibility metadata through to the republish so the
+# mirrored layer accepts the same runtimes/architectures. Read into arrays in a
+# way that works on both bash 3.2 (macOS default) and bash 4+.
+RUNTIMES=()
+while IFS= read -r line; do [[ -n "$line" ]] && RUNTIMES+=("$line"); done \
+  < <(echo "$META" | jq -r '.CompatibleRuntimes[]? // empty')
+ARCHS=()
+while IFS= read -r line; do [[ -n "$line" ]] && ARCHS+=("$line"); done \
+  < <(echo "$META" | jq -r '.CompatibleArchitectures[]? // empty')
+
+[[ -n "$URL" && "$URL" != "null" ]] || die "could not resolve download URL from layer metadata"
+
+# 2. Download the layer zip (no auth required on this pre-signed URL).
+echo "==> Downloading layer content"
+TMP_ZIP="$(mktemp -t sl-layer-XXXXXX.zip)"
+cleanup() { [[ "$KEEP_ZIP" == "true" ]] || rm -f "$TMP_ZIP"; }
+trap cleanup EXIT
+curl -fsSL -o "$TMP_ZIP" "$URL"
+
+# 3. Verify integrity against what AWS reported (base64-encoded SHA-256).
+echo "==> Verifying integrity"
+ACTUAL_SHA="$(openssl dgst -sha256 -binary "$TMP_ZIP" | openssl base64)"
+echo "    expected: ${SHA}"
+echo "    actual  : ${ACTUAL_SHA}"
+[[ "$ACTUAL_SHA" == "$SHA" ]] || die "checksum mismatch — refusing to publish"
+echo "    OK"
+echo
+
+# 4. Republish into YOUR account, recording the source ARN in the description.
+echo "==> Publishing mirrored layer"
+PUBLISH_ARGS=(
+  --layer-name "$TARGET_NAME"
+  --description "Mirror of SeaLights layer. Source ARN: ${SOURCE_ARN}"
+  --zip-file "fileb://${TMP_ZIP}"
+  --region "$REGION"
+)
+[[ "${#RUNTIMES[@]}" -gt 0 ]] && PUBLISH_ARGS+=(--compatible-runtimes "${RUNTIMES[@]}")
+[[ "${#ARCHS[@]}" -gt 0 ]]    && PUBLISH_ARGS+=(--compatible-architectures "${ARCHS[@]}")
+
+RESULT="$(aws lambda publish-layer-version "${PUBLISH_ARGS[@]}")"
+NEW_ARN="$(echo "$RESULT" | jq -r '.LayerVersionArn')"
+
+echo
+echo "==> Done"
+echo "    published: ${NEW_ARN}"
+[[ "$KEEP_ZIP" == "true" ]] && echo "    kept zip : ${TMP_ZIP}"

--- a/lambda-sl-layer-mirror/mirror-sl-layer.sh
+++ b/lambda-sl-layer-mirror/mirror-sl-layer.sh
@@ -2,6 +2,11 @@
 #
 # Mirror a published SeaLights Lambda layer into your own AWS account.
 #
+# Based on the SeaLights example mirror-sl-layer.sh (upstream baseline 1.0.df4c).
+# This is a starting point you are expected to modify. The tag above marks the
+# upstream version you forked from — it does NOT track your local edits, so do
+# not treat it as the version of the script you are actually running.
+#
 set -euo pipefail
 
 # --- source layer names (the 4 published techs) ---------------------------------
@@ -46,13 +51,30 @@ die() {
   exit 1
 }
 
+# All recognized flags — used to detect a missing value (e.g. `--tech --version`).
+KNOWN_FLAGS=(-t --tech -v --version -r --region -n --target-name -k --keep -h --help)
+
+is_flag() {
+  local val="$1"
+  for f in "${KNOWN_FLAGS[@]}"; do
+    [[ "$val" == "$f" ]] && return 0
+  done
+  return 1
+}
+
+# Ensure the option ($1) was given a value ($2) that is non-empty and isn't
+# itself another flag (e.g. `--tech --version` or a trailing `--tech`).
+require_value() {
+  [[ -n "$2" ]] && ! is_flag "$2" || die "$1 requires a value (use --help)"
+}
+
 # --- parse args -----------------------------------------------------------------
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    -t|--tech)           TECH="${2:-}"; shift 2 ;;
-    -v|--version)        VERSION="${2:-}"; shift 2 ;;
-    -r|--region)         REGION="${2:-}"; shift 2 ;;
-    -n|--target-name)    TARGET_NAME="${2:-}"; shift 2 ;;
+    -t|--tech)           require_value "$1" "${2:-}"; TECH="$2"; shift 2 ;;
+    -v|--version)        require_value "$1" "${2:-}"; VERSION="$2"; shift 2 ;;
+    -r|--region)         require_value "$1" "${2:-}"; REGION="$2"; shift 2 ;;
+    -n|--target-name)    require_value "$1" "${2:-}"; TARGET_NAME="$2"; shift 2 ;;
     -k|--keep)           KEEP_ZIP="true"; shift ;;
     -h|--help)           usage; exit 0 ;;
     *) die "unknown argument: $1 (use --help)" ;;
@@ -139,4 +161,6 @@ NEW_ARN="$(echo "$RESULT" | jq -r '.LayerVersionArn')"
 echo
 echo "==> Done"
 echo "    published: ${NEW_ARN}"
-[[ "$KEEP_ZIP" == "true" ]] && echo "    kept zip : ${TMP_ZIP}"
+if [[ "$KEEP_ZIP" == "true" ]]; then
+  echo "    kept zip : ${TMP_ZIP}"
+fi

--- a/lambda-sl-layer-mirror/mirror-sl-layer.sh
+++ b/lambda-sl-layer-mirror/mirror-sl-layer.sh
@@ -1,28 +1,6 @@
 #!/usr/bin/env bash
 #
-# mirror-sl-layer.sh
-#
-# Mirror a published SeaLights Lambda layer from the SeaLights AWS account into
-# your own AWS account. Reads the source layer version (cross-account, no auth on
-# the download URL), verifies its integrity, and republishes it under your account
-# with the original source ARN recorded in the layer description.
-#
-# Usage:
-#   ./mirror-sl-layer.sh --tech <tech> --version <n> --region <region> [options]
-#
-# Required:
-#   -t, --tech <tech>        One of: nodejs-cjs | nodejs-esm | python | java
-#   -v, --version <n>        Source layer version number to mirror
-#   -r, --region <region>    AWS region (e.g. us-east-1, eu-west-1)
-#
-# Optional:
-#   -a, --source-account <id>  Source (SeaLights) account id (default: 442677231940)
-#   -n, --target-name <name>   Layer name to publish into your account
-#                              (default: same as the source layer name)
-#   -k, --keep                 Keep the downloaded layer.zip instead of deleting it
-#   -h, --help                 Show this help and exit
-#
-# Requirements: awscli (configured with YOUR credentials), jq, curl, openssl
+# Mirror a published SeaLights Lambda layer into your own AWS account.
 #
 set -euo pipefail
 
@@ -32,6 +10,7 @@ SL_LAYER_NODEJS_ESM="sl-nodejs-layer-esm"
 SL_LAYER_PYTHON="sl-python-layer"
 SL_LAYER_JAVA="sl-java-layer"
 
+# SeaLights-owned account that publishes the layers.
 SOURCE_ACCOUNT="442677231940"
 
 TECH=""
@@ -41,7 +20,25 @@ TARGET_NAME=""
 KEEP_ZIP="false"
 
 usage() {
-  sed -n '2,25p' "$0" | sed 's/^# \{0,1\}//'
+  cat <<'EOF'
+Mirror a published SeaLights Lambda layer into your own AWS account.
+
+Usage:
+  ./mirror-sl-layer.sh --tech <tech> --version <n> --region <region> [options]
+
+Required:
+  -t, --tech <tech>        One of: nodejs-cjs | nodejs-esm | python | java
+  -v, --version <n>        Source layer version number to mirror
+  -r, --region <region>    AWS region (e.g. us-east-1, eu-west-1)
+
+Optional:
+  -n, --target-name <name>   Layer name to publish into your account
+                             (default: same as the source layer name)
+  -k, --keep                 Keep the downloaded layer.zip instead of deleting it
+  -h, --help                 Show this help and exit
+
+Requirements: awscli (configured with YOUR credentials), jq, curl, openssl
+EOF
 }
 
 die() {
@@ -55,7 +52,6 @@ while [[ $# -gt 0 ]]; do
     -t|--tech)           TECH="${2:-}"; shift 2 ;;
     -v|--version)        VERSION="${2:-}"; shift 2 ;;
     -r|--region)         REGION="${2:-}"; shift 2 ;;
-    -a|--source-account) SOURCE_ACCOUNT="${2:-}"; shift 2 ;;
     -n|--target-name)    TARGET_NAME="${2:-}"; shift 2 ;;
     -k|--keep)           KEEP_ZIP="true"; shift ;;
     -h|--help)           usage; exit 0 ;;
@@ -89,14 +85,6 @@ echo "==> Mirroring SeaLights layer"
 echo "    source ARN : ${SOURCE_ARN}"
 echo "    region     : ${REGION}"
 echo "    target name: ${TARGET_NAME}"
-echo
-
-# 0. Show which account we're about to publish INTO (should be YOUR account).
-CALLER_ACCOUNT="$(aws sts get-caller-identity --query Account --output text 2>/dev/null || echo 'unknown')"
-echo "==> Publishing into account: ${CALLER_ACCOUNT}"
-if [[ "$CALLER_ACCOUNT" == "$SOURCE_ACCOUNT" ]]; then
-  die "your credentials resolve to the SeaLights source account (${SOURCE_ACCOUNT}); use your own account's credentials"
-fi
 echo
 
 # 1. Cross-account read of the source layer metadata (uses YOUR creds; allowed by


### PR DESCRIPTION
## Summary

Adds a self-contained example for customers who cannot reference the externally-published SeaLights Lambda layer ARN directly (e.g. security policies forbidding cross-account layers, isolated environments).

- **`mirror-sl-layer.sh`** — reads a SeaLights-published layer version (cross-account), verifies its checksum, and republishes an identical copy into the customer's own AWS account. The original **source ARN is recorded in the mirrored layer's description**, so the customer can always trace which SeaLights version they're running (AWS layer versions are numbered sequentially per account, so the numbers never line up with SeaLights').
- **`README.md`** — customer-facing explanation of the use case, usage/flags, and an explicit note that the script only mirrors the layer and does not touch their Lambda functions (points to docs.sealights.io for deployment).

The script carries the source layer's compatible runtimes/architectures through to the republish, verifies integrity before publishing, and is portable across macOS bash 3.2 and bash 4+.

## Test plan

- [x] `bash -n mirror-sl-layer.sh` passes (syntax) — verified locally
- [x] `./mirror-sl-layer.sh --help` renders the flag reference — verified locally
- [x] End-to-end mirror against a real layer version in a test AWS account (requires configured AWS creds; reviewer to validate)